### PR TITLE
miss '\' in deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ https://github.com/openfaas/openfaas-cloud/tree/master/of-builder
 
 ```
 $ faas-cli build --parallel=4 \
-  && faas-cli push --parallel=4
+  && faas-cli push --parallel=4 \
   && faas-cli deploy
 ```
 


### PR DESCRIPTION
miss '\' at the end of second line