### PR TITLE
Use upstream buildkit container

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Function cleans up functions which were removed or renamed within the repo for t
 
 * Service: of-builder
 
-A buildkit HTTP daemon which builds the image and pushes it to the internal registry. The image is tagged with the SHA of the Git commit event.
+A builder daemon which exposes the GRPC of-buildkit service via HTTP.
+
+* Service: of-buildkit
+
+The buildkit GRPC daemon which builds the image and pushes it to the internal registry. The image is tagged with the SHA of the Git commit event.
 
 * Service: Docker open-source registry
 

--- a/of-builder/Dockerfile
+++ b/of-builder/Dockerfile
@@ -6,7 +6,7 @@ ADD vendor  vendor
 
 RUN go build -o /usr/bin/of-builder .
 
-FROM tonistiigi/buildkit:standalone
+FROM alexellis2/buildkit:2018-04-17
 COPY --from=builder /usr/bin/of-builder /bin/
 
 EXPOSE 8080

--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -1,15 +1,16 @@
 # Setup
 
-Now setup the registry and builder:
+Now setup the registry and builders:
 
 ```
 docker service rm registry
 docker service create --network func_functions --name registry --detach=true -p 5000:5000  registry:latest
+docker run -d --net func_functions  -d --privileged --name moby-builder tonistiigi/buildkit --addr tcp://0.0.0.0:1234
 
 cd of-builder/
 docker rm -f of-builder
-docker build -t alexellis2/of-builder:0.2 .
-docker run -d --net func_functions -p 8088:8080 --name of-builder --privileged alexellis2/of-builder:0.2
+docker build -t alexellis2/of-builder:0.3 .
+docker run -d --net func_functions -p 8088:8080 --name of-builder --privileged alexellis2/of-builder:0.3
 ```
 
 # Do a test build
@@ -24,7 +25,7 @@ echo '{"Ref": "registry.local:5000/foo/bar:latest"}' > config
 
 mkdir -p context
 echo "## Made with buildkit" >> context/README.md
-cat >context/Dockerfile<<EOT                                                                                            
+cat >context/Dockerfile<<EOT
 FROM busybox
 ADD README.md /
 ENV foo bar

--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -5,12 +5,12 @@ Now setup the registry and builders:
 ```
 docker service rm registry
 docker service create --network func_functions --name registry --detach=true -p 5000:5000  registry:latest
-docker run -d --net func_functions  -d --privileged --name moby-builder tonistiigi/buildkit --addr tcp://0.0.0.0:1234
+docker run -d --net func_functions -d --privileged --name of-buildkit alexellis2/buildkit:2018-04-17 --addr tcp://0.0.0.0:1234
 
 cd of-builder/
 docker rm -f of-builder
 docker build -t alexellis2/of-builder:0.3 .
-docker run -d --net func_functions -p 8088:8080 --name of-builder --privileged alexellis2/of-builder:0.3
+docker run -d --net func_functions -p 8088:8080 --name of-builder alexellis2/of-builder:0.3
 ```
 
 # Do a test build

--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -4,13 +4,13 @@ Now setup the registry and builders:
 
 ```
 docker service rm registry
-docker service create --network func_functions --name registry --detach=true -p 5000:5000  registry:latest
+docker service create --network func_functions --name registry --detach=true -p 5000:5000 registry:latest
 docker run -d --net func_functions -d --privileged --name of-buildkit alexellis2/buildkit:2018-04-17 --addr tcp://0.0.0.0:1234
 
 cd of-builder/
 docker rm -f of-builder
 docker build -t alexellis2/of-builder:0.3 .
-docker run -d --net func_functions -p 8088:8080 --name of-builder alexellis2/of-builder:0.3
+docker service create --network func_functions --name of-builder -p 8088:8080 alexellis2/of-builder:0.3
 ```
 
 # Do a test build

--- a/of-builder/main.go
+++ b/of-builder/main.go
@@ -88,7 +88,7 @@ func build(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 	cmd := exec.Command("buildctl", "--debug", "build", "--frontend=gateway.v0", "--frontend-opt=source="+cfg.Frontend, "--local=context="+filepath.Join(tmpdir, "context"), "--local=dockerfile="+filepath.Join(tmpdir, "context"), "--no-progress", "--exporter=image",
 		"--exporter-opt=name="+cfg.Ref, "--exporter-opt=push=true", "--exporter-opt=registry.insecure=true")
 	env := os.Environ()
-	env = append(env, "BUILDKIT_HOST=tcp://moby-builder:1234")
+	env = append(env, "BUILDKIT_HOST=tcp://of-buildkit:1234")
 	cmd.Env = env
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Uses the current upstream `buildkit` container and changes `of-builder` to point to it via GRPC.

Raising this as a WIP for visibility, will tidy (of-builder tweak) after todays Meetup.

This change was prompted by the following errors encountered on deployments I carried out over the past 24 hours.

See - https://gist.github.com/johnmccabe/1bb2d46221a26507cb136595f90b7ae7