### PR TITLE
Add audit function for gh-push

### DIFF
--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -1,2 +1,3 @@
 environment:
   gateway_url: http://gateway:8080/
+  audit_url: http://gateway:8080/function/audit-event

--- a/stack.yml
+++ b/stack.yml
@@ -6,9 +6,9 @@ functions:
   gh-push:
     lang: go
     handler: ./gh-push
-    image: alexellis2/gh-push:0.1.1
+    image: alexellis2/gh-push:0.2.0
     environment:
-      Http_X_Github_Event: push
+      # Http_X_Github_Event: push
       read_timeout: 5
       write_timeout: 5
       write_debug: true
@@ -76,4 +76,10 @@ functions:
     environment_file:
       - github.yml
       - gateway_config.yml
-
+  audit-event:
+    skip_build: true
+    image: functions/alpine:latest
+    fprocess: cat
+    environment:
+      write_debug: true
+      read_debug: true


### PR DESCRIPTION
Adds auditing for gh-push events so that we can get visibility
of what's going on in the system.

New audit function created for logging but this could be anything
even an external web service.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

## Testing

Sent an event without giving `X-Github-Event` header and then giving a bad value (not "push") and then giving it again with "push"

In each instance I checked out the logs for the audit function to see messages being sent from the function.
