### PR TITLE
Update Deploy-Time label to support kubernetes

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -65,7 +66,7 @@ func Handle(req []byte) string {
 				"Git-Cloud":      "1",
 				"Git-Owner":      owner,
 				"Git-Repo":       repo,
-				"Git-DeployTime": time.Now().String(),
+				"Git-DeployTime": strconv.FormatInt(time.Now().Unix(), 10), //Unix Epoch string
 			},
 			Limits: Limits{
 				Memory: defaultMemoryLimit,


### PR DESCRIPTION
This changes update Deploy-Time label for function to support kubernetes
label validation. Deploy-Time will now use Unix epoch format.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>


Tested on my local on kubernetes . 