### PR TITLE
Allow port as part of repository_url env variable

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -69,7 +69,7 @@ func Handle(req []byte) string {
 		gatewayURL := os.Getenv("gateway_url")
 
 		// Replace image name for "localhost" for deployment
-		imageName = repositoryURL + imageName[strings.Index(imageName, ":"):]
+		imageName = getImageName(repositoryURL, imageName)
 
 		serviceValue = fmt.Sprintf("%s-%s", event.owner, event.service)
 
@@ -311,6 +311,10 @@ func getPrivateKey() string {
 
 func buildStatus(status string, desc string, context string, url string) *github.RepoStatus {
 	return &github.RepoStatus{State: &status, TargetURL: &url, Description: &desc, Context: &context}
+}
+
+func getImageName(repositoryURL, imageName string) string {
+	return repositoryURL + imageName[strings.Index(imageName, "/"):]
 }
 
 type eventInfo struct {

--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -112,5 +112,39 @@ func TestGetEvent_EmptyEnvVars(t *testing.T) {
 		t.Errorf(err.Error())
 		t.Fail()
 	}
+}
 
+var ImageNameTestcases = []struct {
+	Name          string
+	RepositoryURL string
+	ImageName     string
+	Output        string
+}{
+	{
+		"Testcase1",
+		"127.0.0.1:5000",
+		"registry:5000/username/function-name/",
+		"127.0.0.1:5000/username/function-name/",
+	},
+	{
+		"Testcase2",
+		"127.0.0.1:31115",
+		"registry:31115/username/function-name/",
+		"127.0.0.1:31115/username/function-name/",
+	},
+	{
+		"Testcase3",
+		"127.0.0.1",
+		"registry:31115/username/function-name/",
+		"127.0.0.1/username/function-name/",
+	},
+}
+
+func Test_GetImageName(t *testing.T) {
+	for _, testcase := range ImageNameTestcases {
+		output := getImageName(testcase.RepositoryURL, testcase.ImageName)
+		if output != testcase.Output {
+			t.Errorf("%s failed!. got: %s, want: %s", testcase.Name, output, testcase.Output)
+		}
+	}
 }

--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -2,4 +2,5 @@ environment:
   gateway_url: http://gateway:8080/
   gateway_public_url: http://my.openfass.cloud/
   audit_url: http://gateway:8080/function/audit-event
-  repository_url: 127.0.0.1
+  repository_url: 127.0.0.1:5000
+  push_repository_url: registry:5000

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -65,7 +65,14 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 
 		base := filepath.Join(filePath, filepath.Join("build", k))
 
-		imageName := formatImageShaTag("registry:5000", &v, pushEvent.AfterCommitID)
+		pushRepositoryURL := os.Getenv("push_repository_url")
+
+		if len(pushRepositoryURL) == 0 {
+			fmt.Fprintf(os.Stderr, "push_repository_url env-var not set")
+			os.Exit(1)
+		}
+
+		imageName := formatImageShaTag(pushRepositoryURL, &v, pushEvent.AfterCommitID)
 		config := cfg{
 			Ref: imageName,
 		}


### PR DESCRIPTION
This changes to allow port as part of repository_url env variable which
will allow us to specify ports other than 5000 for registry. This will
be required for kubernetes.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

Tested on local for kubernetes. Needs to be tested on Swarm.