### PR TITLE
Add build status as failure in case of code panic

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -33,6 +33,14 @@ func Handle(req []byte) string {
 		log.Panic(eventErr)
 	}
 
+	defer func() {
+		if r := recover(); r != nil {
+			msg := "failed to build function, check builder log for details"
+			reportStatus("failure", msg, "BUILD", event)
+			log.Fatal(msg, r)
+		}
+	}()
+
 	reader := bytes.NewBuffer(req)
 	res, err := http.Post(builderURL+"build", "application/octet-stream", reader)
 	if err != nil {


### PR DESCRIPTION
This commit adds a defer panic code to update failure status in case
there is some Panic

Signed-off-by: Swarvanu Sengupta <swarvanusg@gmail.com>