### PR TITLE
Enable secrets within user namespace

### DIFF
--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 )
@@ -74,4 +75,42 @@ func TestBuildURLWithUndefinedStatusGivesOriginalURL(t *testing.T) {
 		t.Errorf("building PublicURL: want %s, got %s", want, val)
 		t.Fail()
 	}
+}
+
+func TestGetEvent_ReadSecrets(t *testing.T) {
+
+	valSt := []string{"s1", "s2"}
+	val, _ := json.Marshal(valSt)
+	os.Setenv("Http_Secrets", string(val))
+	owner := "alexellis"
+	os.Setenv("Http_Owner", owner)
+
+	eventInfo, err := getEvent()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	expected := []string{owner + "-s1", owner + "-s2"}
+	for _, val := range eventInfo.secrets {
+		found := false
+		for _, expectedVal := range expected {
+			if expectedVal == val {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Wanted secret: %s, didn't find it in list", val)
+		}
+	}
+}
+
+func TestGetEvent_EmptyEnvVars(t *testing.T) {
+	_, err := getEvent()
+
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
 }

--- a/garbage-collect/handler.go
+++ b/garbage-collect/handler.go
@@ -68,9 +68,9 @@ func deleteFunction(target, gatewayURL string) error {
 		Timeout: time.Second * 3,
 	}
 	delReq := struct {
-		Name string
+		FunctionName string
 	}{
-		Name: target,
+		FunctionName: target,
 	}
 
 	bytesReq, _ := json.Marshal(delReq)

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -216,6 +216,13 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services) err
 
 		httpReq.Header.Add("Env", string(envJSON))
 
+		secretsJSON, marshalErr := json.Marshal(stack.Functions[tarEntry.functionName].Secrets)
+		if marshalErr != nil {
+			log.Printf("Error marshaling secrets for function %s, %s", tarEntry.functionName, marshalErr)
+		}
+
+		httpReq.Header.Add("Secrets", string(secretsJSON))
+
 		res, reqErr := c.Do(httpReq)
 		if reqErr != nil {
 			fmt.Fprintf(os.Stderr, fmt.Errorf("unable to deploy function via buildshiprun: %s", reqErr.Error()).Error())

--- a/git-tar/vendor/github.com/openfaas/faas-cli/stack/schema.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/stack/schema.go
@@ -35,6 +35,8 @@ type Function struct {
 	EnvironmentFile []string `yaml:"environment_file"`
 
 	Labels *map[string]string `yaml:"labels"`
+
+	Secrets *[]string `yaml:"secrets"`
 }
 
 // EnvironmentFile represents external file for environment data

--- a/stack.yml
+++ b/stack.yml
@@ -23,7 +23,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: alexellis2/of-git-tar:0.5.0
+    image: alexellis2/of-git-tar:0.6.0
     environment:
       read_timeout: 120
       write_timeout: 120
@@ -35,7 +35,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: alexellis2/of-buildshiprun:0.3.1
+    image: alexellis2/of-buildshiprun:0.4.0
     environment:
       read_timeout: 300
       write_timeout: 300


### PR DESCRIPTION
This change enables users to bind to pre-existing secrets by
specifying them in their stack.yml file - to prevent misuse the
secret is prepended with owner + "-" i.e. "slack1" becomes
"alexellis-slack1"

Additional unit tests are added to cover parsing an empty header
and a valid set of values.

faas-cli needs revendoring to pull in the secrets field

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>