### PR TITLE
Limit number of function per repository

### DIFF
--- a/git-tar/function/handler_test.go
+++ b/git-tar/function/handler_test.go
@@ -1,0 +1,54 @@
+package function
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_IsWithinLimitVariableNotSet(t *testing.T) {
+	os.Unsetenv("functions_per_repo_limit")
+
+	want := true
+	val, _ := isWithinLimit(10)
+
+	if val != want {
+		t.Errorf("Limit check failed: want %v, got %v", want, val)
+		t.Fail()
+	}
+}
+
+func Test_IsWithinLimitInvalidValue(t *testing.T) {
+	os.Setenv("functions_per_repo_limit", "InvalidValue")
+
+	want := false
+	val, _ := isWithinLimit(10)
+
+	if val != want {
+		t.Errorf("Limit check failed: want %v, got %v", want, val)
+		t.Fail()
+	}
+}
+
+func Test_IsWithinLimitTooManyFunctions(t *testing.T) {
+	os.Setenv("functions_per_repo_limit", "5")
+
+	want := false
+	val, _ := isWithinLimit(10)
+
+	if val != want {
+		t.Errorf("Limit check failed: want %v, got %v", want, val)
+		t.Fail()
+	}
+}
+
+func Test_IsWithinLimitTooFewFunctions(t *testing.T) {
+	os.Setenv("functions_per_repo_limit", "5")
+
+	want := true
+	val, _ := isWithinLimit(4)
+
+	if val != want {
+		t.Errorf("Limit check failed: want %v, got %v", want, val)
+		t.Fail()
+	}
+}

--- a/github.yml
+++ b/github.yml
@@ -3,3 +3,4 @@ environment:
     github_app_id: "12345"
     report_status: "true"
     private_key_filename: ""
+    functions_per_repo_limit: 5 # Number of function per repository


### PR DESCRIPTION
This changes limits number of function per repository for OpenFaaS
cloud. By default it is 5 and can be changed using
`functions_limit_count` environment variable in `gateway_config.yml`

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

Fixes #50 