### PR TITLE
Allow usage of shared public Docker Repository

### DIFF
--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -117,25 +117,36 @@ func TestGetEvent_EmptyEnvVars(t *testing.T) {
 func Test_GetImageName(t *testing.T) {
 
 	var imageNameTestcases = []struct {
-		Name          string
-		RepositoryURL string
-		ImageName     string
-		Output        string
+		Name              string
+		PushRepositoryURL string
+		RepositoryURL     string
+		ImageName         string
+		Output            string
 	}{
 		{
+			"Test Docker Hub with user-prefix",
+			"docker.io/of-community/",
+			"docker.io/of-community/",
+			"docker.io/of-community/function-name/",
+			"docker.io/of-community/function-name/",
+		},
+		{
 			"Testcase1",
+			"registry:5000",
 			"127.0.0.1:5000",
 			"registry:5000/username/function-name/",
 			"127.0.0.1:5000/username/function-name/",
 		},
 		{
 			"Testcase2",
+			"registry:31115",
 			"127.0.0.1:31115",
 			"registry:31115/username/function-name/",
 			"127.0.0.1:31115/username/function-name/",
 		},
 		{
 			"Testcase3",
+			"registry:31115",
 			"127.0.0.1",
 			"registry:31115/username/function-name/",
 			"127.0.0.1/username/function-name/",
@@ -143,9 +154,11 @@ func Test_GetImageName(t *testing.T) {
 	}
 
 	for _, testcase := range imageNameTestcases {
-		output := getImageName(testcase.RepositoryURL, testcase.ImageName)
-		if output != testcase.Output {
-			t.Errorf("%s failed!. got: %s, want: %s", testcase.Name, output, testcase.Output)
-		}
+		t.Run(testcase.Name, func(t *testing.T) {
+			output := getImageName(testcase.RepositoryURL, testcase.PushRepositoryURL, testcase.ImageName)
+			if output != testcase.Output {
+				t.Errorf("%s failed!. got: %s, want: %s", testcase.Name, output, testcase.Output)
+			}
+		})
 	}
 }

--- a/git-tar/function/format_test.go
+++ b/git-tar/function/format_test.go
@@ -6,26 +6,70 @@ import (
 	"github.com/openfaas/faas-cli/stack"
 )
 
-func TestImageNameSuffix_WithoutLatestTag(t *testing.T) {
+func Test_FormatImageShaTag_PrivateRepo_WithTag_NoStackPrefix(t *testing.T) {
+	function := &stack.Function{
+		Image: "func:0.2",
+	}
+
+	owner := "alexellis"
+	repo := "go-fns-tester"
+	sha := "04b8e44988"
+
+	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
+
+	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44988"
+	if name != want {
+		t.Errorf("Want \"%s\", got \"%s\"", want, name)
+	}
+}
+
+func Test_FormatImageShaTag_PrivateRepo_WithTag(t *testing.T) {
+	function := &stack.Function{
+		Image: "alexellis2/func:0.2",
+	}
+
+	owner := "alexellis"
+	repo := "go-fns-tester"
+	sha := "04b8e44988"
+
+	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
+
+	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44988"
+	if name != want {
+		t.Errorf("Want \"%s\", got \"%s\"", want, name)
+	}
+}
+
+func Test_FormatImageShaTag_PrivateRepo_NoTag(t *testing.T) {
 	function := &stack.Function{
 		Image: "alexellis2/func",
 	}
 
-	name := formatImageShaTag("registry:5000", function, "thesha")
-	want := "registry:5000/alexellis2/func:latest-thesha"
+	owner := "alexellis"
+	repo := "go-fns-tester"
+	sha := "04b8e44988"
+
+	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
+
+	want := "registry:5000/" + owner + "/" + repo + "-func:latest-04b8e44988"
 	if name != want {
-		t.Errorf("Want %s, got %s.", want, name)
+		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
 }
 
-func TestImageNameSuffix_WithSpecificTag(t *testing.T) {
+func Test_FormatImageShaTag_SharedRepo_NoTag(t *testing.T) {
 	function := &stack.Function{
-		Image: "alexellis2/func:0.1",
+		Image: "alexellis2/func",
 	}
 
-	name := formatImageShaTag("registry:5000", function, "thesha")
-	want := "registry:5000/alexellis2/func:0.1-thesha"
+	owner := "alexellis"
+	repo := "go-fns-tester"
+	sha := "04b8e44988"
+
+	name := formatImageShaTag("docker.io/of-community/", function, sha, owner, repo)
+
+	want := "docker.io/of-community/" + owner + "-" + repo + "-func:latest-04b8e44988"
 	if name != want {
-		t.Errorf("Want %s, got %s.", want, name)
+		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
 }

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -72,7 +72,9 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 			os.Exit(1)
 		}
 
-		imageName := formatImageShaTag(pushRepositoryURL, &v, pushEvent.AfterCommitID)
+		imageName := formatImageShaTag(pushRepositoryURL, &v, pushEvent.AfterCommitID,
+			pushEvent.Repository.Owner.Login, pushEvent.Repository.Name)
+
 		config := cfg{
 			Ref: imageName,
 		}
@@ -135,17 +137,31 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 	return tars, nil
 }
 
-func formatImageShaTag(registry string, function *stack.Function, sha string) string {
+func formatImageShaTag(registry string, function *stack.Function, sha string, owner string, repo string) string {
 	tag := ":latest"
+
 	imageName := function.Image
 	tagIndex := strings.LastIndex(function.Image, ":")
+
 	if tagIndex > 0 {
 		tag = function.Image[tagIndex:]
 		imageName = function.Image[:tagIndex]
 	}
 
-	imageName = registry + "/" + imageName + tag + "-" + sha
-	return imageName
+	repoIndex := strings.LastIndex(imageName, "/")
+	if repoIndex > -1 {
+		imageName = imageName[repoIndex+1:]
+	}
+
+	var imageRef string
+	sharedRepo := strings.HasSuffix(registry, "/")
+	if sharedRepo {
+		imageRef = registry[:len(registry)-1] + "/" + owner + "-" + repo + "-" + imageName + tag + "-" + sha
+	} else {
+		imageRef = registry + "/" + owner + "/" + repo + "-" + imageName + tag + "-" + sha
+	}
+
+	return imageRef
 }
 
 func clone(pushEvent sdk.PushEvent) (string, error) {

--- a/sample-json/go-fns.json
+++ b/sample-json/go-fns.json
@@ -1,0 +1,192 @@
+{
+    "ref": "refs/heads/master",
+    "before": "89925a01976c82e0fac1be72ac81c28e542ea234",
+    "after": "27c584a2bcb7843f79249dfb058d6daeb164d69f",
+    "created": false,
+    "deleted": false,
+    "forced": false,
+    "base_ref": null,
+    "compare": "https://github.com/alexellis/go-fns-tester/compare/89925a01976c...27c584a2bcb7",
+    "commits": [
+      {
+        "id": "27c584a2bcb7843f79249dfb058d6daeb164d69f",
+        "tree_id": "c8fe1c01d5857319af126ed225fd82f685326b12",
+        "distinct": true,
+        "message": "Update stack.yml",
+        "timestamp": "2018-05-23T14:39:04+01:00",
+        "url": "https://github.com/alexellis/go-fns-tester/commit/27c584a2bcb7843f79249dfb058d6daeb164d69f",
+        "author": {
+          "name": "Alex Ellis",
+          "email": "alexellis2@gmail.com",
+          "username": "alexellis"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "username": "web-flow"
+        },
+        "added": [
+  
+        ],
+        "removed": [
+  
+        ],
+        "modified": [
+          "stack.yml"
+        ]
+      }
+    ],
+    "head_commit": {
+      "id": "27c584a2bcb7843f79249dfb058d6daeb164d69f",
+      "tree_id": "c8fe1c01d5857319af126ed225fd82f685326b12",
+      "distinct": true,
+      "message": "Update stack.yml",
+      "timestamp": "2018-05-23T14:39:04+01:00",
+      "url": "https://github.com/alexellis/go-fns-tester/commit/27c584a2bcb7843f79249dfb058d6daeb164d69f",
+      "author": {
+        "name": "Alex Ellis",
+        "email": "alexellis2@gmail.com",
+        "username": "alexellis"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "username": "web-flow"
+      },
+      "added": [
+  
+      ],
+      "removed": [
+  
+      ],
+      "modified": [
+        "stack.yml"
+      ]
+    },
+    "repository": {
+      "id": 131475375,
+      "name": "go-fns-tester",
+      "full_name": "alexellis/go-fns-tester",
+      "owner": {
+        "name": "alexellis",
+        "email": "alexellis2@gmail.com",
+        "login": "alexellis",
+        "id": 6358735,
+        "avatar_url": "https://avatars1.githubusercontent.com/u/6358735?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/alexellis",
+        "html_url": "https://github.com/alexellis",
+        "followers_url": "https://api.github.com/users/alexellis/followers",
+        "following_url": "https://api.github.com/users/alexellis/following{/other_user}",
+        "gists_url": "https://api.github.com/users/alexellis/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/alexellis/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/alexellis/subscriptions",
+        "organizations_url": "https://api.github.com/users/alexellis/orgs",
+        "repos_url": "https://api.github.com/users/alexellis/repos",
+        "events_url": "https://api.github.com/users/alexellis/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/alexellis/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "private": false,
+      "html_url": "https://github.com/alexellis/go-fns-tester",
+      "description": "Tests OpenFaaS Cloud status API with passing/failing builds",
+      "fork": false,
+      "url": "https://github.com/alexellis/go-fns-tester",
+      "forks_url": "https://api.github.com/repos/alexellis/go-fns-tester/forks",
+      "keys_url": "https://api.github.com/repos/alexellis/go-fns-tester/keys{/key_id}",
+      "collaborators_url": "https://api.github.com/repos/alexellis/go-fns-tester/collaborators{/collaborator}",
+      "teams_url": "https://api.github.com/repos/alexellis/go-fns-tester/teams",
+      "hooks_url": "https://api.github.com/repos/alexellis/go-fns-tester/hooks",
+      "issue_events_url": "https://api.github.com/repos/alexellis/go-fns-tester/issues/events{/number}",
+      "events_url": "https://api.github.com/repos/alexellis/go-fns-tester/events",
+      "assignees_url": "https://api.github.com/repos/alexellis/go-fns-tester/assignees{/user}",
+      "branches_url": "https://api.github.com/repos/alexellis/go-fns-tester/branches{/branch}",
+      "tags_url": "https://api.github.com/repos/alexellis/go-fns-tester/tags",
+      "blobs_url": "https://api.github.com/repos/alexellis/go-fns-tester/git/blobs{/sha}",
+      "git_tags_url": "https://api.github.com/repos/alexellis/go-fns-tester/git/tags{/sha}",
+      "git_refs_url": "https://api.github.com/repos/alexellis/go-fns-tester/git/refs{/sha}",
+      "trees_url": "https://api.github.com/repos/alexellis/go-fns-tester/git/trees{/sha}",
+      "statuses_url": "https://api.github.com/repos/alexellis/go-fns-tester/statuses/{sha}",
+      "languages_url": "https://api.github.com/repos/alexellis/go-fns-tester/languages",
+      "stargazers_url": "https://api.github.com/repos/alexellis/go-fns-tester/stargazers",
+      "contributors_url": "https://api.github.com/repos/alexellis/go-fns-tester/contributors",
+      "subscribers_url": "https://api.github.com/repos/alexellis/go-fns-tester/subscribers",
+      "subscription_url": "https://api.github.com/repos/alexellis/go-fns-tester/subscription",
+      "commits_url": "https://api.github.com/repos/alexellis/go-fns-tester/commits{/sha}",
+      "git_commits_url": "https://api.github.com/repos/alexellis/go-fns-tester/git/commits{/sha}",
+      "comments_url": "https://api.github.com/repos/alexellis/go-fns-tester/comments{/number}",
+      "issue_comment_url": "https://api.github.com/repos/alexellis/go-fns-tester/issues/comments{/number}",
+      "contents_url": "https://api.github.com/repos/alexellis/go-fns-tester/contents/{+path}",
+      "compare_url": "https://api.github.com/repos/alexellis/go-fns-tester/compare/{base}...{head}",
+      "merges_url": "https://api.github.com/repos/alexellis/go-fns-tester/merges",
+      "archive_url": "https://api.github.com/repos/alexellis/go-fns-tester/{archive_format}{/ref}",
+      "downloads_url": "https://api.github.com/repos/alexellis/go-fns-tester/downloads",
+      "issues_url": "https://api.github.com/repos/alexellis/go-fns-tester/issues{/number}",
+      "pulls_url": "https://api.github.com/repos/alexellis/go-fns-tester/pulls{/number}",
+      "milestones_url": "https://api.github.com/repos/alexellis/go-fns-tester/milestones{/number}",
+      "notifications_url": "https://api.github.com/repos/alexellis/go-fns-tester/notifications{?since,all,participating}",
+      "labels_url": "https://api.github.com/repos/alexellis/go-fns-tester/labels{/name}",
+      "releases_url": "https://api.github.com/repos/alexellis/go-fns-tester/releases{/id}",
+      "deployments_url": "https://api.github.com/repos/alexellis/go-fns-tester/deployments",
+      "created_at": 1524987605,
+      "updated_at": "2018-05-22T14:48:18Z",
+      "pushed_at": 1527082745,
+      "git_url": "git://github.com/alexellis/go-fns-tester.git",
+      "ssh_url": "git@github.com:alexellis/go-fns-tester.git",
+      "clone_url": "https://github.com/alexellis/go-fns-tester.git",
+      "svn_url": "https://github.com/alexellis/go-fns-tester",
+      "homepage": null,
+      "size": 32,
+      "stargazers_count": 0,
+      "watchers_count": 0,
+      "language": "Go",
+      "has_issues": true,
+      "has_projects": true,
+      "has_downloads": true,
+      "has_wiki": true,
+      "has_pages": false,
+      "forks_count": 1,
+      "mirror_url": null,
+      "archived": false,
+      "open_issues_count": 0,
+      "license": {
+        "key": "mit",
+        "name": "MIT License",
+        "spdx_id": "MIT",
+        "url": "https://api.github.com/licenses/mit"
+      },
+      "forks": 1,
+      "open_issues": 0,
+      "watchers": 0,
+      "default_branch": "master",
+      "stargazers": 0,
+      "master_branch": "master"
+    },
+    "pusher": {
+      "name": "alexellis",
+      "email": "alexellis2@gmail.com"
+    },
+    "sender": {
+      "login": "alexellis",
+      "id": 6358735,
+      "avatar_url": "https://avatars1.githubusercontent.com/u/6358735?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/alexellis",
+      "html_url": "https://github.com/alexellis",
+      "followers_url": "https://api.github.com/users/alexellis/followers",
+      "following_url": "https://api.github.com/users/alexellis/following{/other_user}",
+      "gists_url": "https://api.github.com/users/alexellis/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/alexellis/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/alexellis/subscriptions",
+      "organizations_url": "https://api.github.com/users/alexellis/orgs",
+      "repos_url": "https://api.github.com/users/alexellis/repos",
+      "events_url": "https://api.github.com/users/alexellis/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/alexellis/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "installation": {
+      "id": 67049
+    }
+  }

--- a/stack.yml
+++ b/stack.yml
@@ -22,7 +22,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: alexellis2/of-git-tar:0.6.2
+    image: alexellis2/of-git-tar:0.6.3
     environment:
       read_timeout: 120
       write_timeout: 120
@@ -34,7 +34,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: alexellis2/of-buildshiprun:0.4.2
+    image: alexellis2/of-buildshiprun:0.4.3
     environment:
       read_timeout: 300
       write_timeout: 300


### PR DESCRIPTION
For easier usage on Kubernetes and cloud Docker Repositories a
single account can be used and specified via repository_url i.e.
docker.io/getfaas/ vs registry:5000/

Tested on Kubernetes with shared Docker Hub account.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>