### PR TITLE
Redirect Derek file to openfaas/faas file

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -1,16 +1,1 @@
-maintainers:
- - alexellis
- - rgee0
- - johnmccabe
- - jockdarock
- - ericstoekl
- - itscaro
- - kenfdev
- - BurtonR
- - iyovcheva
- - stefanprodan
-
-features:
- - dco_check
- - comments
- 
+ redirect: https://raw.githubusercontent.com/openfaas/faas/master/.DEREK.yml 


### PR DESCRIPTION
The OpenFaas organization uses several repositories for the code
base that are all related. Consolidating the derek file will make
it easier to maintain when adding or removing users

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Description
This change redirects the derek file to the main openfaas/faas
repo to allow us to maintain a single source of authorized derek
users at the main repository.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] updated the documentation if required - not required
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests - Not required

This comes from the faas repo issue: https://github.com/openfaas/faas/issues/630