### PR TITLE
Add audit for call to import-secrets

### DIFF
--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/openfaas/openfaas-cloud/sdk"
 )
 
+const Source = "git-tar"
+
 // Handle a serverless request
 func Handle(req []byte) []byte {
 
@@ -50,7 +52,7 @@ func Handle(req []byte) []byte {
 		os.Exit(-1)
 	}
 
-	err = importSecrets(pushEvent, clonePath)
+	err = importSecrets(pushEvent, stack, clonePath)
 	if err != nil {
 		log.Printf("Error parsing secrets: %s\n", err.Error())
 		os.Exit(-1)


### PR DESCRIPTION
Add audit for call to import-secrets

## Description
This adds an audit call from `git-tar` when the `importSecrets()` method is called from. Tells the audit-event collector that secrets were parsed for the particular function owner.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed openfaas-cloud on my GKE cluster, installed SealedSecret CRD, and added the `secrets.yml` file to my github repo. When pushing to that github repo, I see the audit event show up in the `audit-event` collector.

```
2018/06/18 04:54:02 Event: {"Source":"gh-tar","Message":"Parsed sealed secrets for owner: ericstoekl","Owner":"ericstoekl","Repo":"bot-tester"}
```

## Checklist:

I have:

- [ ] updated the documentation if required
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

