### PR TITLE
Verify import-secrets is called via git-tar with HMAC

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -302,17 +302,8 @@ func reportStatus(status string, desc string, statusContext string, event *event
 	}
 
 	url := buildPublicStatusURL(status, event)
-
 	ctx := context.Background()
-
-	// NOTE: currently vendored derek auth package doesn't take the private key as input;
-	// but expect it to be present at : "/run/secrets/derek-private-key"
-	// as docker /secrets dir has limited permission we are bound to use secret named
-	// as "derek-private-key"
-	// the below lines should  be uncommented once the package is updated in derek project
 	privateKeyPath := getPrivateKey()
-	// token, tokenErr := auth.MakeAccessTokenForInstallation(os.Getenv("github_app_id"),
-	// 	event.installationID, privateKeyPath)
 
 	repoStatus := buildStatus(status, desc, statusContext, url)
 

--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -53,7 +53,7 @@ func Handle(req []byte) string {
 		reportStatus("failure", err.Error(), "BUILD", event)
 		auditEvent.Message = fmt.Sprintf("buildshiprun failure: %s", err.Error())
 		sdk.PostAudit(auditEvent)
-		return ""
+		return auditEvent.Message
 	}
 
 	defer res.Body.Close()

--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -1,9 +1,9 @@
 environment:
-  gateway_url: http://gateway:8080/
-  gateway_public_url: http://my.openfass.cloud/
-  audit_url: http://gateway:8080/function/audit-event
-  repository_url: 127.0.0.1:5000
-  push_repository_url: registry:5000
+  gateway_url:  http://gateway.openfaas:8080/
+  gateway_public_url: https://cloud.o6s.io/
+  audit_url: http://gateway.openfaas:8080/function/audit-event
+  repository_url: docker.io/ofcommunity/
+  push_repository_url: docker.io/ofcommunity/
   basic_auth: true
   secret_mount_path: /var/openfaas/secrets
   private_key: private-key
@@ -12,3 +12,6 @@ environment:
 #  repository_url: docker.io/ofcommunity/
 #  push_repository_url: docker.io/ofcommunity/
 
+# Private repo config
+# repository_url: 127.0.0.1:5000
+# push_repository_url: registry:5000

--- a/git-tar/Dockerfile
+++ b/git-tar/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build /usr/bin/fwatchdog         .
 COPY --from=build /usr/local/bin/faas-cli    /usr/local/bin/faas-cli
 RUN chmod 777 /tmp
 USER app
-RUN faas-cli template pull https://github.com/openfaas-incubator/node8-express-template
+# RUN faas-cli template pull https://github.com/openfaas-incubator/node8-express-template
 ENV fprocess="./handler"
 
 CMD ["./fwatchdog"]

--- a/git-tar/Gopkg.lock
+++ b/git-tar/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/alexellis/hmac"
+  packages = ["."]
+  revision = "d5d71edd7bc74eb6ae4b99eccc6bda738435f43f"
+  version = "1.2"
+
+[[projects]]
   name = "github.com/openfaas/faas-cli"
   packages = ["stack"]
   revision = "6532f3c66967b3a872208a29b1b60a873b7d2490"
@@ -26,6 +32,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c62f7a77ac2d22e709ca96fe1b9584589fd551064446ef4f84811fee62f6da35"
+  inputs-digest = "b72ad07d2868979bd36a5cfd20d9ca28b4449f622b1b55c03f853cb1dc2b6f89"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/git-tar/Gopkg.toml
+++ b/git-tar/Gopkg.toml
@@ -36,3 +36,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "github.com/alexellis/hmac"
+  version = "1.2.0"

--- a/git-tar/vendor/github.com/alexellis/hmac/README.md
+++ b/git-tar/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/git-tar/vendor/github.com/alexellis/hmac/pkg.go
+++ b/git-tar/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/import-secrets/Gopkg.lock
+++ b/import-secrets/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/alexellis/hmac"
+  packages = ["."]
+  revision = "d5d71edd7bc74eb6ae4b99eccc6bda738435f43f"
+  version = "1.2"
+
+[[projects]]
   name = "github.com/bitnami-labs/sealed-secrets"
   packages = [
     "pkg/apis/sealed-secrets/v1alpha1",
@@ -200,6 +206,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d8a77f15cd33f62732b00b5e935ac85f3ded42b0ac69a11f31d189af6040d696"
+  inputs-digest = "5b0c70f49eeff5c68b555d314059caa19916c86b611e856e88123097f98daa3a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/import-secrets/Gopkg.toml
+++ b/import-secrets/Gopkg.toml
@@ -160,3 +160,7 @@
 [[override]]
   name = "k8s.io/kube-openapi"
   revision = "8a9b82f00b3a86eac24681da3f9fe6c34c01cea2"
+
+[[constraint]]
+  name = "github.com/alexellis/hmac"
+  version = "1.2.0"

--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -18,6 +18,7 @@ import (
 
 // Handle a serverless request
 func Handle(req []byte) string {
+	event := getEventFromHeader()
 
 	if hmacEnabled() {
 		key := getHMACSecretKey()
@@ -31,9 +32,9 @@ func Handle(req []byte) string {
 
 			return "Unable to validate HMAC"
 		}
+		fmt.Fprintf(os.Stderr, "hash for HMAC validated successfully for %s\n", event.owner)
 	}
 
-	event := getEventFromHeader()
 	config, err := rest.InClusterConfig()
 
 	if err != nil {

--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 
+	hmac "github.com/alexellis/hmac"
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
 	ssv1alpha1clientset "github.com/bitnami-labs/sealed-secrets/pkg/client/clientset/versioned/typed/sealed-secrets/v1alpha1"
 	errors2 "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +18,22 @@ import (
 
 // Handle a serverless request
 func Handle(req []byte) string {
-	event := getEvent()
+
+	if hmacEnabled() {
+		key := getHMACSecretKey()
+		digest := os.Getenv("Http_X_Hub_Signature")
+
+		validated := hmac.Validate(req, digest, key)
+
+		if validated != nil {
+			fmt.Fprintf(os.Stderr, validated.Error())
+			os.Exit(1)
+
+			return "Unable to validate HMAC"
+		}
+	}
+
+	event := getEventFromHeader()
 	config, err := rest.InClusterConfig()
 
 	if err != nil {
@@ -92,6 +108,14 @@ func Handle(req []byte) string {
 	return fmt.Sprintf("Imported SealedSecret: %s as new object", name)
 }
 
+func getHMACSecretKey() string {
+	return os.Getenv("github_secret_key")
+}
+
+func hmacEnabled() bool {
+	return os.Getenv("validate_hmac") == "1" || os.Getenv("validate_hmac") == "true"
+}
+
 func updateEncryptedData(ss *ssv1alpha1.SealedSecret, userSecret *SealedSecret) error {
 	for k, v := range userSecret.Spec.EncryptedData {
 		encodedBytes, err := base64.StdEncoding.DecodeString(v)
@@ -106,10 +130,10 @@ func updateEncryptedData(ss *ssv1alpha1.SealedSecret, userSecret *SealedSecret) 
 	return nil
 }
 
-func getEvent() *eventInfo {
-	info := eventInfo{}
-
-	info.owner = os.Getenv("Http_Owner")
+func getEventFromHeader() *eventInfo {
+	info := eventInfo{
+		owner: os.Getenv("Http_Owner"),
+	}
 
 	return &info
 }

--- a/import-secrets/vendor/github.com/alexellis/hmac/README.md
+++ b/import-secrets/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/import-secrets/vendor/github.com/alexellis/hmac/pkg.go
+++ b/import-secrets/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/slack.yml
+++ b/slack.yml
@@ -1,2 +1,2 @@
 environment:
-  slack_url: http://gateway:8080/function/echo
+  slack_url: http://gateway.openfaas:8080/function/echo

--- a/stack.yml
+++ b/stack.yml
@@ -6,11 +6,12 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: alexellis2/github-push:0.4.1
+    image: alexellis2/github-push:0.4.2
     labels:
       openfaas-cloud: "1"
     environment:
       # Http_X_Github_Event: push
+      validate_hmac: true
       read_timeout: 10s
       write_timeout: 10s
       write_debug: true
@@ -24,7 +25,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: alexellis2/of-git-tar:0.6.5
+    image: alexellis2/of-git-tar:0.6.7
     labels:
       openfaas-cloud: "1"
     environment:
@@ -38,7 +39,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: alexellis2/of-buildshiprun:0.4.6
+    image: alexellis2/of-buildshiprun:0.4.7
     labels:
       openfaas-cloud: "1"
     environment:
@@ -74,7 +75,7 @@ functions:
   garbage-collect:
     lang: go
     handler: ./garbage-collect
-    image: alexellis2/garbage-collect:0.3.1
+    image: alexellis2/garbage-collect:0.3.2
     labels:
       openfaas-cloud: "1"
     environment:
@@ -91,7 +92,7 @@ functions:
   github-event:
     lang: go
     handler: ./github-event
-    image: alexellis2/github-event:0.4.1
+    image: alexellis2/github-event:0.4.2
     labels:
       openfaas-cloud: "1"
     environment:
@@ -104,7 +105,7 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: alexellis2/import-secrets:0.1.0
+    image: alexellis2/import-secrets:0.2.0
     labels:
       openfaas-cloud: "1"
     environment:

--- a/stack.yml
+++ b/stack.yml
@@ -105,12 +105,16 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: alexellis2/import-secrets:0.2.0
+    image: alexellis2/import-secrets:0.2.1
     labels:
       openfaas-cloud: "1"
     environment:
       write_debug: true
       read_debug: true
+      validate_hmac: true
+      combined_output: false
+    environment_file:
+      - github.yml
 
   echo:
     skip_build: true


### PR DESCRIPTION
## Description

Verify import-secrets is called via git-tar with HMAC

See issue: #78 

From `git log`:

```
    Update import-secrets to validate HMAC
    HMAC is now used to verify import-secrets was called from git-tar
    and not from another function. This re-uses the secret used for    GitHub validation.

    - hmac re-vendored and pinned at version with Sign() method
    - git-tar now signs payload    - import-secrets now validates source

    Testing - via unit test / build. E2E testing to follow with new
    images published.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested through end-to-end testing.

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

