### PR TITLE
Add failure handling in buildshiprun

### DIFF
--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -162,3 +162,19 @@ func Test_GetImageName(t *testing.T) {
 		})
 	}
 }
+
+func Test_ValidImage(t *testing.T) {
+	imageNames := map[string]bool{
+		"failed to solve: rpc error: code = Unknown desc = exit code 2":   false,
+		"failed to solve: rpc error: code = Unknown desc = exit status 2": false,
+		"failed to solve:":                                                false,
+		"error:":                                                          false,
+		"code =":                                                          false,
+		"127.0.0.1:5000/someuser/regex_go-regex_py": true,
+	}
+	for image, expected := range imageNames {
+		if validImage(image) != expected {
+			t.Errorf("For image %s, got: %v, want: %v", image, !expected, expected)
+		}
+	}
+}


### PR DESCRIPTION
1. add regex to validate if image name is valid
2. check builder response status code

Signed-off-by: s8sg <swarvanusg@gmail.com>

## Description
This PR implements better error handling in buildshiprun. 
Fixes #84 

## How Has This Been Tested?
This is tested with [https://github.com/s8sg/regex_go](https://github.com/s8sg/regex_go) with forcefully committing error at commit [4343faf](https://github.com/s8sg/regex_go/commit/4343faf081aa2e9866930969dcf5c43054c91cff)
    
The `validImage()` check code are tested using the testcases:
```go
"failed to solve: rpc error: code = Unknown desc = exit code 2":   false,
"failed to solve: rpc error: code = Unknown desc = exit status 2": false,
"failed to solve:":                                                false,
"error:":                                                          false,
"code =":                                                          false,
"127.0.0.1:5000/someuser/regex_go-regex_py": true,
``` 
    
The updated code looks like:
> Invalid Image Check
```go
if !validImage(imageName) {
```
> Invalid Response status check
```go
if res.StatusCode < 200 || res.StatusCode > 299 {
```


## Checklist:

I have:

- [x] updated the documentation if required (not required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests