### PR TITLE
Uses `faas-cli` package to tag image name

### DIFF
--- a/git-tar/Gopkg.lock
+++ b/git-tar/Gopkg.lock
@@ -9,9 +9,12 @@
 
 [[projects]]
   name = "github.com/openfaas/faas-cli"
-  packages = ["stack"]
-  revision = "6532f3c66967b3a872208a29b1b60a873b7d2490"
-  version = "0.6.9"
+  packages = [
+    "schema",
+    "stack"
+  ]
+  revision = "b5597294da6dd98457434fafe39054c993a5f7e7"
+  version = "0.6.17"
 
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
@@ -32,6 +35,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b72ad07d2868979bd36a5cfd20d9ca28b4449f622b1b55c03f853cb1dc2b6f89"
+  inputs-digest = "877c4535c0c288857c4cea4acaf69022f457828b68e7d9f84d6e0a0542b13ca8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/git-tar/Gopkg.toml
+++ b/git-tar/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas-cli"
-  version = "0.6.9"
+  version = "0.6.17"
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -16,6 +16,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/openfaas/faas-cli/schema"
+
 	hmac "github.com/alexellis/hmac"
 	"github.com/openfaas/faas-cli/stack"
 	"github.com/openfaas/openfaas-cloud/sdk"
@@ -141,27 +143,20 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 }
 
 func formatImageShaTag(registry string, function *stack.Function, sha string, owner string, repo string) string {
-	tag := ":latest"
-
 	imageName := function.Image
-	tagIndex := strings.LastIndex(function.Image, ":")
-
-	if tagIndex > 0 {
-		tag = function.Image[tagIndex:]
-		imageName = function.Image[:tagIndex]
-	}
 
 	repoIndex := strings.LastIndex(imageName, "/")
 	if repoIndex > -1 {
 		imageName = imageName[repoIndex+1:]
 	}
+	imageName = schema.BuildImageName(schema.SHAFormat, imageName, sha, "master")
 
 	var imageRef string
 	sharedRepo := strings.HasSuffix(registry, "/")
 	if sharedRepo {
-		imageRef = registry[:len(registry)-1] + "/" + owner + "-" + repo + "-" + imageName + tag + "-" + sha
+		imageRef = registry[:len(registry)-1] + "/" + owner + "-" + repo + "-" + imageName
 	} else {
-		imageRef = registry + "/" + owner + "/" + repo + "-" + imageName + tag + "-" + sha
+		imageRef = registry + "/" + owner + "/" + repo + "-" + imageName
 	}
 
 	return imageRef

--- a/git-tar/vendor/github.com/openfaas/faas-cli/schema/image.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/schema/image.go
@@ -1,0 +1,31 @@
+package schema
+
+import (
+	"strings"
+)
+
+type BuildFormat int
+
+// DefaultFormat as defined in the YAML file or appending :latest
+const DefaultFormat BuildFormat = 0
+
+const SHAFormat BuildFormat = 1
+
+const BranchAndSHAFormat BuildFormat = 2
+
+// BuildImageName builds a Docker image tag for build, push or deploy
+func BuildImageName(format BuildFormat, image string, SHA string, branch string) string {
+	imageVal := image
+	if strings.Contains(image, ":") == false {
+		imageVal += ":latest"
+	}
+
+	if format == SHAFormat {
+		return imageVal + "-" + SHA
+	}
+	if format == BranchAndSHAFormat {
+		return imageVal + "-" + branch + "-" + SHA
+	}
+
+	return imageVal
+}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/schema/secret.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/schema/secret.go
@@ -1,0 +1,13 @@
+package schema
+
+type KubernetesSecret struct {
+	Kind       string                   `json:"kind"`
+	ApiVersion string                   `json:"apiVersion"`
+	Metadata   KubernetesSecretMetadata `json:"metadata"`
+	Data       map[string]string        `json:"data"`
+}
+
+type KubernetesSecretMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/schema/store_item.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/schema/store_item.go
@@ -1,0 +1,15 @@
+package schema
+
+// StoreItem represents an item of store
+type StoreItem struct {
+	Icon        string            `json:"icon"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	Image       string            `json:"image"`
+	Name        string            `json:"name"`
+	Fprocess    string            `json:"fprocess"`
+	Network     string            `json:"network"`
+	RepoURL     string            `json:"repo_url"`
+	Environment map[string]string `json:"environment"`
+	Labels      map[string]string `json:"labels"`
+}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/stack/language_template.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/stack/language_template.go
@@ -63,3 +63,16 @@ func IsValidTemplate(lang string) bool {
 
 	return found
 }
+
+//LoadLanguageTemplate loads language template details from template.yml file.
+func LoadLanguageTemplate(lang string) (*LanguageTemplate, error) {
+	lang = strings.ToLower(lang)
+	_, err := os.Stat("./template/" + lang)
+
+	if err == nil {
+		templateYAMLPath := "./template/" + lang + "/template.yml"
+		languageTemplate, err := ParseYAMLForLanguageTemplate(templateYAMLPath)
+		return languageTemplate, err
+	}
+	return nil, err
+}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/stack/schema.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/stack/schema.go
@@ -47,6 +47,15 @@ type Function struct {
 
 	// Requests of resources requested by function
 	Requests *FunctionResources `yaml:"requests"`
+
+	// ReadOnlyRootFilesystem is used to set the container filesystem to read-only
+	ReadOnlyRootFilesystem bool `yaml:"readonly_root_filesystem"`
+
+	// BuildOptions to determine native packages
+	BuildOptions []string `yaml:"build_options"`
+
+	// Annotations
+	Annotations *map[string]string `yaml:"annotations"`
 }
 
 // FunctionResources Memory and CPU
@@ -68,6 +77,14 @@ type Services struct {
 
 // LanguageTemplate read from template.yml within root of a language template folder
 type LanguageTemplate struct {
-	Language string `yaml:"language"`
-	FProcess string `yaml:"fprocess"`
+	Language     string        `yaml:"language"`
+	FProcess     string        `yaml:"fprocess"`
+	BuildOptions []BuildOption `yaml:"build_options"`
+	// WelcomeMessage is printed to the user after generating a function
+	WelcomeMessage string `yaml:"welcome_message"`
+}
+
+type BuildOption struct {
+	Name     string   `yaml:"name"`
+	Packages []string `yaml:"packages"`
 }


### PR DESCRIPTION
This commit uses `faas-cli` package to tag images for openfaas cloud
functions.

Fixes: #87

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

