### PR TITLE
Use short SHA for image name tag

### DIFF
--- a/git-tar/function/format_test.go
+++ b/git-tar/function/format_test.go
@@ -17,7 +17,7 @@ func Test_FormatImageShaTag_PrivateRepo_WithTag_NoStackPrefix(t *testing.T) {
 
 	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
 
-	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44988"
+	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
@@ -34,7 +34,7 @@ func Test_FormatImageShaTag_PrivateRepo_WithTag(t *testing.T) {
 
 	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
 
-	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44988"
+	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
@@ -51,7 +51,7 @@ func Test_FormatImageShaTag_PrivateRepo_NoTag(t *testing.T) {
 
 	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
 
-	want := "registry:5000/" + owner + "/" + repo + "-func:latest-04b8e44988"
+	want := "registry:5000/" + owner + "/" + repo + "-func:latest-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
@@ -68,7 +68,7 @@ func Test_FormatImageShaTag_SharedRepo_NoTag(t *testing.T) {
 
 	name := formatImageShaTag("docker.io/of-community/", function, sha, owner, repo)
 
-	want := "docker.io/of-community/" + owner + "-" + repo + "-func:latest-04b8e44988"
+	want := "docker.io/of-community/" + owner + "-" + repo + "-func:latest-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -149,6 +149,9 @@ func formatImageShaTag(registry string, function *stack.Function, sha string, ow
 	if repoIndex > -1 {
 		imageName = imageName[repoIndex+1:]
 	}
+
+	sha = getShortSHA(sha)
+
 	imageName = schema.BuildImageName(schema.SHAFormat, imageName, sha, "master")
 
 	var imageRef string
@@ -320,4 +323,12 @@ func importSecrets(pushEvent sdk.PushEvent, stack *stack.Services, clonePath str
 	fmt.Println("Parsed sealed secrets", res.Status, owner)
 
 	return nil
+}
+
+//getShortSHA returns shorter version of git commit SHA
+func getShortSHA(sha string) string {
+	if len(sha) <= 7 {
+		return sha
+	}
+	return sha[:7]
 }


### PR DESCRIPTION
This changes uses shorter version of SHA for images tags.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests

