### PR TITLE
HMAC validation for github-status + stack-deploy Status failure if any function fails

### DIFF
--- a/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
+++ b/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
@@ -1,0 +1,26 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// ReadSecret reads a secret from /var/openfaas/secrets or from
+// env-var 'secret_mount_path' if set.
+func ReadSecret(key string) (string, error) {
+	basePath := "/var/openfaas/secrets/"
+	if len(os.Getenv("secret_mount_path")) > 0 {
+		basePath = os.Getenv("secret_mount_path")
+	}
+
+	readPath := path.Join(basePath, key)
+	secretBytes, readErr := ioutil.ReadFile(readPath)
+	if readErr != nil {
+		return "", fmt.Errorf("unable to read secret: %s, error: %s", readPath, readErr)
+	}
+	val := strings.TrimSpace(string(secretBytes))
+	return val, nil
+}

--- a/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -42,7 +42,6 @@ func Handle(req []byte) string {
 	log.Printf("%d env-vars for %s", len(event.Environment), serviceValue)
 
 	status := sdk.BuildStatus(event, sdk.EmptyAuthToken)
-	status.SetHmacKey(os.Getenv("github_webhook_secret"))
 
 	reader := bytes.NewBuffer(req)
 
@@ -309,7 +308,13 @@ func reportStatus(status *sdk.Status) {
 
 	gatewayURL := os.Getenv("gateway_url")
 
-	_, reportErr := status.Report(gatewayURL)
+	hmacKey, keyErr := sdk.ReadSecret("github-webhook-secret")
+	if keyErr != nil {
+		log.Printf("failed to load hmac key for status, error " + keyErr.Error())
+		return
+	}
+
+	_, reportErr := status.Report(gatewayURL, hmacKey)
 	if reportErr != nil {
 		log.Printf("failed to report status, error: %s", reportErr.Error())
 	}

--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -42,6 +42,7 @@ func Handle(req []byte) string {
 	log.Printf("%d env-vars for %s", len(event.Environment), serviceValue)
 
 	status := sdk.BuildStatus(event, sdk.EmptyAuthToken)
+	status.SetHmacKey(os.Getenv("github_webhook_secret"))
 
 	reader := bytes.NewBuffer(req)
 

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
+++ b/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
@@ -1,0 +1,26 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// ReadSecret reads a secret from /var/openfaas/secrets or from
+// env-var 'secret_mount_path' if set.
+func ReadSecret(key string) (string, error) {
+	basePath := "/var/openfaas/secrets/"
+	if len(os.Getenv("secret_mount_path")) > 0 {
+		basePath = os.Getenv("secret_mount_path")
+	}
+
+	readPath := path.Join(basePath, key)
+	secretBytes, readErr := ioutil.ReadFile(readPath)
+	if readErr != nil {
+		return "", fmt.Errorf("unable to read secret: %s, error: %s", readPath, readErr)
+	}
+	val := strings.TrimSpace(string(secretBytes))
+	return val, nil
+}

--- a/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -66,14 +66,17 @@ func Handle(req []byte) []byte {
 	err = importSecrets(pushEvent, stack, clonePath)
 	if err != nil {
 		log.Printf("Error parsing secrets: %s\n", err.Error())
+		status.AddStatus(sdk.StatusFailure, "failed to parse secrets, error : "+err.Error(), sdk.StackContext)
+		reportStatus(status)
 		os.Exit(-1)
 	}
 
 	err = deploy(tars, pushEvent, stack, status)
 	if err != nil {
-		status.AddStatus(sdk.StatusFailure, "stack deploy failed, error : "+err.Error(), sdk.StackContext)
+		status.AddStatus(sdk.StatusFailure, "deploy failed, error : "+err.Error(), sdk.StackContext)
 		reportStatus(status)
 		log.Printf("deploy error: %s", err)
+		os.Exit(-1)
 	}
 
 	status.AddStatus(sdk.StatusSuccess, "stack is successfully deployed", sdk.StackContext)

--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -28,7 +28,6 @@ func Handle(req []byte) []byte {
 
 	statusEvent := sdk.BuildEventFromPushEvent(pushEvent)
 	status := sdk.BuildStatus(statusEvent, sdk.EmptyAuthToken)
-	status.SetHmacKey(os.Getenv("github_webhook_secret"))
 
 	clonePath, err := clone(pushEvent)
 	if err != nil {
@@ -145,9 +144,15 @@ func reportStatus(status *sdk.Status) {
 		return
 	}
 
+	hmacKey, keyErr := sdk.ReadSecret("github-webhook-secret")
+	if keyErr != nil {
+		log.Printf("failed to load hmac key for status, error " + keyErr.Error())
+		return
+	}
+
 	gatewayURL := os.Getenv("gateway_url")
 
-	_, reportErr := status.Report(gatewayURL)
+	_, reportErr := status.Report(gatewayURL, hmacKey)
 	if reportErr != nil {
 		log.Printf("failed to report status, error: %s", reportErr.Error())
 	}

--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -28,6 +28,7 @@ func Handle(req []byte) []byte {
 
 	statusEvent := sdk.BuildEventFromPushEvent(pushEvent)
 	status := sdk.BuildStatus(statusEvent, sdk.EmptyAuthToken)
+	status.SetHmacKey(os.Getenv("github_webhook_secret"))
 
 	clonePath, err := clone(pushEvent)
 	if err != nil {

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/github-push/handler.go
+++ b/github-push/handler.go
@@ -102,6 +102,7 @@ func Handle(req []byte) string {
 
 	eventInfo := sdk.BuildEventFromPushEvent(pushEvent)
 	status := sdk.BuildStatus(eventInfo, sdk.EmptyAuthToken)
+	status.SetHmacKey(os.Getenv("github_webhook_secret"))
 	status.AddStatus(sdk.StatusPending, fmt.Sprintf("%s stack deploy is in progress", serviceValue), sdk.StackContext)
 	reportStatus(status)
 

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/github-status/handler.go
+++ b/github-status/handler.go
@@ -28,10 +28,14 @@ var (
 func Handle(req []byte) string {
 
 	if hmacEnabled() {
-		key := getHMACSecretKey()
-		digest := os.Getenv("Http_X_Hub_Signature")
 
-		fmt.Println(digest)
+		key, keyErr := sdk.ReadSecret("github-webhook-secret")
+		if keyErr != nil {
+			fmt.Fprintf(os.Stderr, keyErr.Error())
+			os.Exit(-1)
+		}
+
+		digest := os.Getenv("Http_X_Hub_Signature")
 
 		validated := hmac.Validate(req, digest, key)
 
@@ -158,10 +162,6 @@ func getPrivateKey() string {
 	}
 	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
 	return privateKeyPath
-}
-
-func getHMACSecretKey() string {
-	return os.Getenv("github_webhook_secret")
 }
 
 func hmacEnabled() bool {

--- a/github-status/handler_test.go
+++ b/github-status/handler_test.go
@@ -336,7 +336,7 @@ func TestStatusReportFailure(t *testing.T) {
 	status.AddStatus(sdk.StatusPending, "description stack", sdk.StackContext)
 
 	gateway := "invalid:8080/"
-	token, err := status.Report(gateway)
+	token, err := status.Report(gateway, "")
 	if token != "" {
 		t.Errorf("validating report failure token: want %v got %v", "", token)
 	}

--- a/github-status/vendor/github.com/alexellis/hmac/README.md
+++ b/github-status/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/github-status/vendor/github.com/alexellis/hmac/pkg.go
+++ b/github-status/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
@@ -1,0 +1,26 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// ReadSecret reads a secret from /var/openfaas/secrets or from
+// env-var 'secret_mount_path' if set.
+func ReadSecret(key string) (string, error) {
+	basePath := "/var/openfaas/secrets/"
+	if len(os.Getenv("secret_mount_path")) > 0 {
+		basePath = os.Getenv("secret_mount_path")
+	}
+
+	readPath := path.Join(basePath, key)
+	secretBytes, readErr := ioutil.ReadFile(readPath)
+	if readErr != nil {
+		return "", fmt.Errorf("unable to read secret: %s, error: %s", readPath, readErr)
+	}
+	val := strings.TrimSpace(string(secretBytes))
+	return val, nil
+}

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/secrets.go
@@ -1,0 +1,26 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// ReadSecret reads a secret from /var/openfaas/secrets or from
+// env-var 'secret_mount_path' if set.
+func ReadSecret(key string) (string, error) {
+	basePath := "/var/openfaas/secrets/"
+	if len(os.Getenv("secret_mount_path")) > 0 {
+		basePath = os.Getenv("secret_mount_path")
+	}
+
+	readPath := path.Join(basePath, key)
+	secretBytes, readErr := ioutil.ReadFile(readPath)
+	if readErr != nil {
+		return "", fmt.Errorf("unable to read secret: %s, error: %s", readPath, readErr)
+	}
+	val := strings.TrimSpace(string(secretBytes))
+	return val, nil
+}

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -42,7 +42,6 @@ type Status struct {
 	CommitStatuses map[string]CommitStatus `json:"commit-statuses"`
 	EventInfo      Event                   `json:"event"`
 	AuthToken      string                  `json:"auth-token"`
-	hmacKey        string                  `json:"-"`
 }
 
 // BuildStatus constructs a status object from event
@@ -54,11 +53,6 @@ func BuildStatus(event *Event, token string) *Status {
 	status.AuthToken = token
 
 	return &status
-}
-
-// Add Hmac Key to status object
-func (status *Status) SetHmacKey(key string) {
-	status.hmacKey = key
 }
 
 // UnmarshalStatus unmarshal a status object from json
@@ -109,9 +103,7 @@ func UnmarshalToken(data []byte) (string, error) {
 
 	err := json.Unmarshal(data, &tokenMap)
 	if err != nil {
-		return EmptyAuthToken, fmt.Errorf(`invalid auth token format received, %s.
-error: %v
-make sure combine_output is disabled for github-status`, err, data)
+		return EmptyAuthToken, fmt.Errorf(`invalid auth token format received: %s. error: %s, make sure combine_output is disabled for github-status`, data, err)
 	}
 
 	token := tokenMap[tokenKey]
@@ -123,20 +115,20 @@ make sure combine_output is disabled for github-status`, token)
 }
 
 // Report send a status update to github-status function
-func (status *Status) Report(gateway string) (string, error) {
+func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	body, _ := status.Marshal()
 
 	var hash []byte
 	// sign with hmac key if set
-	if len(status.hmacKey) > 0 {
-		hash = hmac.Sign(body, []byte(status.hmacKey))
+	if len(hmacKey) > 0 {
+		hash = hmac.Sign(body, []byte(hmacKey))
 	}
 
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
-	if len(status.hmacKey) > 0 {
+	if len(hmacKey) > 0 {
 		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -2,8 +2,10 @@ package sdk
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -40,6 +42,7 @@ type Status struct {
 	CommitStatuses map[string]CommitStatus `json:"commit-statuses"`
 	EventInfo      Event                   `json:"event"`
 	AuthToken      string                  `json:"auth-token"`
+	hmacKey        string                  `json:"-"`
 }
 
 // BuildStatus constructs a status object from event
@@ -51,6 +54,11 @@ func BuildStatus(event *Event, token string) *Status {
 	status.AuthToken = token
 
 	return &status
+}
+
+// Add Hmac Key to status object
+func (status *Status) SetHmacKey(key string) {
+	status.hmacKey = key
 }
 
 // UnmarshalStatus unmarshal a status object from json
@@ -118,9 +126,19 @@ make sure combine_output is disabled for github-status`, token)
 func (status *Status) Report(gateway string) (string, error) {
 	body, _ := status.Marshal()
 
+	var hash []byte
+	// sign with hmac key if set
+	if len(status.hmacKey) > 0 {
+		hash = hmac.Sign(body, []byte(status.hmacKey))
+	}
+
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
+
+	if len(status.hmacKey) > 0 {
+		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+	}
 
 	res, err := c.Do(httpReq)
 	if err != nil {
@@ -128,9 +146,14 @@ func (status *Status) Report(gateway string) (string, error) {
 	}
 
 	defer res.Body.Close()
-	resData, _ := ioutil.ReadAll(res.Body)
-	if resData == nil {
-		return "", fmt.Errorf("empty token received")
+
+	resData, readErr := ioutil.ReadAll(res.Body)
+	if resData == nil || readErr != nil {
+		return "", fmt.Errorf("failed to read response from github-status")
+	}
+
+	if res.StatusCode != http.StatusAccepted && res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to call github-status, invalid status: %s", res.Status)
 	}
 
 	status.AuthToken, err = UnmarshalToken(resData)

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/sdk/Gopkg.toml
+++ b/sdk/Gopkg.toml
@@ -33,3 +33,6 @@
   version = "0.8.2"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+   name = "github.com/alexellis/hmac"
+   version = "1.2.0"

--- a/sdk/vendor/github.com/alexellis/hmac/README.md
+++ b/sdk/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/sdk/vendor/github.com/alexellis/hmac/pkg.go
+++ b/sdk/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/stack.yml
+++ b/stack.yml
@@ -6,7 +6,7 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: alexellis2/github-push:0.5.2
+    image: alexellis2/github-push:0.5.3
     labels:
       openfaas-cloud: "1"
     environment:
@@ -27,7 +27,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: alexellis2/of-git-tar:0.7.2
+    image: alexellis2/of-git-tar:0.7.3
     labels:
       openfaas-cloud: "1"
     environment:
@@ -44,7 +44,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: alexellis2/of-buildshiprun:0.5.1
+    image: alexellis2/of-buildshiprun:0.5.2
     labels:
       openfaas-cloud: "1"
     environment:
@@ -97,18 +97,18 @@ functions:
   github-status:
     lang: go
     handler: ./github-status
-    image: alexellis2/github-status:0.1.2
+    image: alexellis2/github-status:0.1.3
     environment:
       write_debug: true
       read_debug: true
       combine_output: false
+      validate_hmac: true
     environment_file:
       - gateway_config.yml
       - github.yml
     secrets:
       - private-key
-      - basic-auth-user
-      - basic-auth-password
+      - github-webhook-secret
 
   github-event:
     lang: go


### PR DESCRIPTION
## Description
This PR add the below changes:
1. Provide `stack-deploy` Status failure if any function fails
2. Add HMAC validation for `github-status`

## How Has This Been Tested?

#### Change 1
It is tested by complete deploytment of `of-cloud`
Below things are tested:
1. If one Function fails, if `stack-deploy` marked as error
2. If all function fails, if `stack-deploy` marked as error
3. If None fails, if `stack-deploy` marked as success

Stack Deploy Failure Example:
![screenshot 2018-08-10 at 6 05 06 pm](https://user-images.githubusercontent.com/7374058/43949254-f9c94116-9cc7-11e8-946e-9dd7e75e4286.png)


#### Change 2
It is tested by complete deploytment of `of-cloud`
Below things are tested:
1. If hmac verify is disable
2. If hmac verify is enable
3. If invalid hmac (verify github-status log)
4. If invalid hmac (verify callers failure log )

## Checklist:

I have:
- [ ] updated the documentation if required
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [X] added unit tests
