### PR TITLE
Capture logs from of-builder

### DIFF
--- a/CUSTOMERS
+++ b/CUSTOMERS
@@ -21,3 +21,4 @@ rorpage
 martindekov
 james-r-smith
 AlexEllisUK
+hugomd

--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -167,7 +167,7 @@ func Handle(req []byte) string {
 	sdk.PostAudit(auditEvent)
 	status.AddStatus(sdk.StatusSuccess, fmt.Sprintf("deployed: %s", serviceValue), sdk.BuildFunctionContext(event.Service))
 	reportStatus(status)
-	return fmt.Sprintf("buildStatus %s %s %s", buildStatus, imageName, res.Status)
+	return fmt.Sprintf("buildStatus %v %s %s", status, imageName, res.Status)
 }
 
 // readOnlyRootFS defaults to true, override with env-var of readonly_root_filesystem=false

--- a/of-builder/.gitignore
+++ b/of-builder/.gitignore
@@ -1,2 +1,3 @@
 of-builder
+test-script.sh
 test-image

--- a/of-builder/Dockerfile
+++ b/of-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS builder
+FROM golang:1.10.3-alpine AS builder
 RUN apk add --no-cache git g++ linux-headers
 WORKDIR /go/src/github.com/alexellis/of-cloud/of-builder
 ADD main.go .
@@ -8,18 +8,17 @@ RUN go build -o /usr/bin/of-builder .
 
 FROM alpine:3.7
 
-RUN addgroup -S app && adduser -S -g app app
-RUN mkdir -p /home/app
+RUN addgroup -S app && adduser app -S -G app \
+ && mkdir -p /home/app
 
 WORKDIR /home/app
 
 COPY --from=builder /usr/bin/of-builder /home/app/
 
-RUN chown -R app /home/app
+RUN chown -R app:app /home/app
 USER app
 
-
 EXPOSE 8080
-VOLUME /tmp
+VOLUME /tmp/
 
 ENTRYPOINT ["/home/app/of-builder"]

--- a/of-builder/Dockerfile
+++ b/of-builder/Dockerfile
@@ -8,14 +8,17 @@ RUN go build -o /usr/bin/of-builder .
 
 FROM alpine:3.7
 
-RUN addgroup -S app && adduser app -S -G app \
+# Setting the group prevented access to /tmp at runtime
+# lchown started to fail
+# -G app 
+RUN addgroup -S app && adduser app -S \
  && mkdir -p /home/app
 
 WORKDIR /home/app
 
 COPY --from=builder /usr/bin/of-builder /home/app/
 
-RUN chown -R app:app /home/app
+RUN chown -R app /home/app
 USER app
 
 EXPOSE 8080

--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -87,7 +87,7 @@ The builder service calls into the buildkit daemon to build an OpenFaaS function
 ```
 cd of-builder/
 docker rm -f of-builder
-export OF_BUILDER_TAG=0.4.3
+export OF_BUILDER_TAG=0.5.1
 make
 
 make push
@@ -96,7 +96,7 @@ make push
 ### Deploy
 
 ```
-export OF_BUILDER_TAG=0.4.3
+export OF_BUILDER_TAG=0.5.1
 docker service create --network func_functions --name of-builder openfaas/of-builder:$OF_BUILDER_TAG
 ```
 

--- a/of-builder/deploy_swarm.sh
+++ b/of-builder/deploy_swarm.sh
@@ -12,7 +12,7 @@ docker run -d --net func_functions -d --privileged \
 --restart always \
 --name of-buildkit alexellis2/buildkit:2018-04-17 --addr tcp://0.0.0.0:1234
 
-export OF_BUILDER_TAG=0.4.2
+export OF_BUILDER_TAG=0.5.1
 
 # You should mount your .docker/config.json file here, but first make sure it is
 # readable. `chmod 777 $HOME/.docker/config.json`

--- a/of-builder/deploy_swarm.sh
+++ b/of-builder/deploy_swarm.sh
@@ -16,7 +16,10 @@ export OF_BUILDER_TAG=0.5.1
 
 # You should mount your .docker/config.json file here, but first make sure it is
 # readable. `chmod 777 $HOME/.docker/config.json`
-docker service rm of-builder
-docker service create --constraint="node.role==manager" --detach=true \
- --network func_functions --name of-builder openfaas/of-builder:$OF_BUILDER_TAG
 
+docker service create --constraint="node.role==manager" \
+ --name of-builder \
+ --env insecure=false --detach=true --network func_functions \
+ --secret src=registry-secret,target="/home/app/.docker/config.json" \
+ --env enable_lchown=false \
+openfaas/of-builder:$OF_BUILDER_TAG

--- a/sdk/build.go
+++ b/sdk/build.go
@@ -1,0 +1,5 @@
+package sdk
+
+type Build struct {
+	Line []string
+}

--- a/sdk/events.go
+++ b/sdk/events.go
@@ -24,6 +24,27 @@ type Installation struct {
 	ID int `json:"id"`
 }
 
+// PushEvent as received from GitLab
+
+type GitLabPushEvent struct {
+	Ref              string           `json:"ref"`
+	UserUsername     string           `json:"user_username"`
+	UserEmail        string           `json:"user_email"`
+	GitLabProject    GitLabProject    `json:"project"`
+	GitLabRepository GitLabRepository `json:"repository"`
+	AfterCommitID    string           `json:"after"`
+}
+
+type GitLabProject struct {
+	Namespace         string `json:"namespace"`
+	Name              string `json:"name"`
+	PathWithNamespace string `json:"path_with_namespace"` //would be repo full name
+}
+
+type GitLabRepository struct {
+	CloneURL string `json:"git_http_url"`
+}
+
 // Event info to pass/store events across functions
 type Event struct {
 	Service        string            `json:"service"`

--- a/sdk/events.go
+++ b/sdk/events.go
@@ -2,20 +2,26 @@ package sdk
 
 // PushEvent as received from GitHub
 type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Owner    struct {
-			Login string `json:"login"`
-			Email string `json:"email"`
-		} `json:"owner"`
-	}
-	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Ref           string       `json:"ref"`
+	Repository    Repository   `json:"repository"`
+	AfterCommitID string       `json:"after"`
+	Installation  Installation `json:"installation"`
+}
+
+type Repository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Owner    Owner  `json:"owner"`
+}
+
+type Owner struct {
+	Login string `json:"login"`
+	Email string `json:"email"`
+}
+
+type Installation struct {
+	ID int `json:"id"`
 }
 
 // Event info to pass/store events across functions

--- a/yaml/of-builder-dep.yml
+++ b/yaml/of-builder-dep.yml
@@ -16,8 +16,13 @@ spec:
             secretName: registry-secret
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.4.1
+        image: openfaas/of-builder:0.5.0
         imagePullPolicy: Always
+        environment:
+          - name: enable_lchown
+            value: "true"
+          - name: insecure
+            value: "false"
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/yaml/of-builder-dep.yml
+++ b/yaml/of-builder-dep.yml
@@ -16,7 +16,7 @@ spec:
             secretName: registry-secret
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.5.0
+        image: openfaas/of-builder:0.5.1
         imagePullPolicy: Always
         environment:
           - name: enable_lchown


### PR DESCRIPTION
## Description

A struct is now returned as JSON from of-builder containing an
array of lines from buildkit and the imagename/status.

Tested locally with Docker for Mac - I received logs on a
positive/negative build.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests