### PR TITLE
Break PushEvent struct into small structs

### DIFF
--- a/sdk/events.go
+++ b/sdk/events.go
@@ -2,20 +2,26 @@ package sdk
 
 // PushEvent as received from GitHub
 type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Owner    struct {
-			Login string `json:"login"`
-			Email string `json:"email"`
-		} `json:"owner"`
-	}
-	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Ref           string       `json:"ref"`
+	Repository    Repository   `json:"repository"`
+	AfterCommitID string       `json:"after"`
+	Installation  Installation `json:"installation"`
+}
+
+type Repository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Owner    Owner  `json:"owner"`
+}
+
+type Owner struct {
+	Login string `json:"login"`
+	Email string `json:"email"`
+}
+
+type Installation struct {
+	ID int `json:"id"`
 }
 
 // Event info to pass/store events across functions

--- a/stack.yml
+++ b/stack.yml
@@ -6,7 +6,7 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: alexellis2/github-push:0.5.2
+    image: alexellis/github-push:0.5.2
     labels:
       openfaas-cloud: "1"
     environment:


### PR DESCRIPTION
I am breaking down the anonymous PushEvent struct to
small pieces so its more readable and easier to populate outisde
json

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Breaking anonymous PushEvent structure to small pieces so it can be populated
manually easier and be more readable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Builded github-push function, deployed and made push event to the openfaas-cloud to see
the function deployed on the cloud.

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

