### PR TITLE
Add gitlab payload handling struct

### DIFF
--- a/sdk/events.go
+++ b/sdk/events.go
@@ -24,6 +24,27 @@ type Installation struct {
 	ID int `json:"id"`
 }
 
+// PushEvent as received from GitLab
+
+type GitLabPushEvent struct {
+	Ref              string           `json:"ref"`
+	UserUsername     string           `json:"user_username"`
+	UserEmail        string           `json:"user_email"`
+	GitLabProject    GitLabProject    `json:"project"`
+	GitLabRepository GitLabRepository `json:"repository"`
+	AfterCommitID    string           `json:"after"`
+}
+
+type GitLabProject struct {
+	Namespace         string `json:"namespace"`
+	Name              string `json:"name"`
+	PathWithNamespace string `json:"path_with_namespace"` //would be repo full name
+}
+
+type GitLabRepository struct {
+	CloneURL string `json:"git_http_url"`
+}
+
 // Event info to pass/store events across functions
 type Event struct {
 	Service        string            `json:"service"`


### PR DESCRIPTION
Adding struct that can handle the payloads that gitlab gives
on push hook or system hook

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Adding struct below PushEvent that can handle push/system hooks from gitlab

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

