### PR TITLE
Change environment to env in of-builder-dep.yml

### DIFF
--- a/yaml/of-builder-dep.yml
+++ b/yaml/of-builder-dep.yml
@@ -18,7 +18,7 @@ spec:
       - name: of-builder
         image: openfaas/of-builder:0.5.1
         imagePullPolicy: Always
-        environment:
+        env:
           - name: enable_lchown
             value: "true"
           - name: insecure


### PR DESCRIPTION
Fixes #104

The proper syntax for defining environment variables in the container section of kubernetes' yaml is by using "env:", not "environment:".

Signed-off-by: Kiril Vuchkov <kirilvuchkov@gmail.com>

## Description
Minor syntax issue in the of-builder-dep.yml is preventing from deploying the openfaas-cloud builder - issue #104.

## How Has This Been Tested?

By running ```kubectl apply -f ./yaml``` I am able to deploy a functional openfaas-cloud instance.

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
