### PR TITLE
Adds docker login tips for Mac and Windows to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -175,6 +175,7 @@ This populates `~/.docker/config.json` which is used in the builder:
 }
 
 ```
+> Note: the auth string above is using an example value and is not a real authentication string.
 
 #### For Kubernetes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,15 +125,56 @@ You will need to edit `stack.yml` and make sure `buildshiprun_limits_swarm.yml` 
 
 ### Deploy your container builder
 
-Make sure Docker for Mac / Windows isn't storing your credentials in its keychain. If you're on Linux there is no need to make a change.
+You need to generate the ```~/.docker/config.json``` using the ```docker login``` command. 
 
+If you are not on Linux, i.e. you are on Mac or Windows, docker stores credentials in credentials store by default and your docker config.json file will look like this:
+```
+{
+  "credSstore" : "osxkeychain",
+  "auths" : {
+    "https://index.docker.io/v1/" : {
+
+    }
+  },
+  "HttpHeaders" : {
+    "User-Agent" : "Docker-Client/18.06.0-ce (darwin)"
+  }
+}
+```
+Run ```docker login``` to generate the ```config.json``` (if you haven't already) and edit it by removing the "credSstore" property:
+```json
+{
+  "auths" : {
+    "https://index.docker.io/v1/" : {
+
+    }
+  },
+  "HttpHeaders" : {
+    "User-Agent" : "Docker-Client/18.06.0-ce (darwin)"
+  }
+}
+```
 Log into your registry or the Docker hub
 
 ```
 docker login
 ```
+Expect to see ```WARNING! Your password will be stored unencrypted in /Users/kvuchkov/.docker/config.json``` in the output.
 
-This populates `~/.docker/config.json` which is used in the builder.
+This populates `~/.docker/config.json` which is used in the builder:
+```json
+{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "asdf12djs37ASfs732sFa3fdsw=="
+		}
+	},
+	"HttpHeaders": {
+		"User-Agent": "Docker-Client/18.06.0-ce (darwin)"
+	}
+}
+
+```
 
 #### For Kubernetes
 


### PR DESCRIPTION
docker login uses credentials store by default on Mac and Windows. It will be very convenient if we include a simple instruction how to work around this and be able to deploy openfaas-cloud localy with ease.

Signed-off-by: Kiril Vuchkov <kirilvuchkov@gmail.com>

## Description


## How Has This Been Tested?
I've tried the instructions myself on Mac. I haven't tested this on Windows, however it should be the same.

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
