### PR TITLE
Use separate key for internal trust

### DIFF
--- a/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -129,7 +129,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,26 @@ Any account
 The GitHub app will deliver webhooks to your OpenFaaS Cloud instance every time code is pushed in a user's function repository. Make sure you provide the public URL for your OpenFaaS gateway to the GitHub app. Like:  
 `http://my.openfaas.cloud/function/github-push`
 
+### Create an internal trust secret
+
+This secret will be used by each OpenFaaS Cloud function to validate requests and to sign calls it needs to make to other functions.
+
+```
+PAYLOAD_SECRET=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+```
+
+Kubernetes:
+
+```bash
+kubectl create secret generic -n openfaas-fn payload-secret --from-literal payload-secret="$PAYLOAD_SECRET"
+```
+
+Swarm:
+
+```bash
+echo -n "$PAYLOAD_SECRET" | docker secret create payload-secret -
+```
+
 ### Set your GitHub App config
 
 #### Set the App ID

--- a/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -144,7 +144,7 @@ func reportStatus(status *sdk.Status) {
 		return
 	}
 
-	hmacKey, keyErr := sdk.ReadSecret("github-webhook-secret")
+	hmacKey, keyErr := sdk.ReadSecret("payload-secret")
 	if keyErr != nil {
 		log.Printf("failed to load hmac key for status, error " + keyErr.Error())
 		return

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/github-push/handler.go
+++ b/github-push/handler.go
@@ -38,7 +38,7 @@ func Handle(req []byte) string {
 
 	shouldValidate := readBool("validate_hmac")
 	if shouldValidate {
-		webhookSecretKey, secretErr := sdk.ReadSecret("payload-secret")
+		webhookSecretKey, secretErr := sdk.ReadSecret("github-webhook-secret")
 		if secretErr != nil {
 			return secretErr.Error()
 		}
@@ -185,10 +185,6 @@ func postEvent(pushEvent sdk.PushEvent) (int, error) {
 	return res.StatusCode, nil
 }
 
-func init() {
-
-}
-
 func readBool(key string) bool {
 	if val, exists := os.LookupEnv(key); exists {
 		return val == "true" || val == "1"
@@ -218,4 +214,8 @@ func reportStatus(status *sdk.Status) {
 	if reportErr != nil {
 		log.Printf("failed to report status, error: %s", reportErr.Error())
 	}
+}
+
+func init() {
+
 }

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/github-status/handler.go
+++ b/github-status/handler.go
@@ -29,13 +29,13 @@ func Handle(req []byte) string {
 
 	if hmacEnabled() {
 
-		key, keyErr := sdk.ReadSecret("github-webhook-secret")
+		key, keyErr := sdk.ReadSecret("payload-secret")
 		if keyErr != nil {
 			fmt.Fprintf(os.Stderr, keyErr.Error())
 			os.Exit(-1)
 		}
 
-		digest := os.Getenv("Http_X_Hub_Signature")
+		digest := os.Getenv("Http_X_Cloud_Signature")
 
 		validated := hmac.Validate(req, digest, key)
 

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -22,7 +22,7 @@ func Handle(req []byte) string {
 	event := getEventFromHeader()
 
 	if hmacEnabled() {
-		key, err := sdk.ReadSecret("github-webhook-secret")
+		key, err := sdk.ReadSecret("payload-secret")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())
 			os.Exit(1)
@@ -30,7 +30,7 @@ func Handle(req []byte) string {
 			return err.Error()
 		}
 
-		digest := os.Getenv("Http_X_Hub_Signature")
+		digest := os.Getenv("Http_X_Cloud_Signature")
 
 		validated := hmac.Validate(req, digest, key)
 

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/pipeline-log/handler.go
+++ b/pipeline-log/handler.go
@@ -21,8 +21,15 @@ func Handle(req []byte) string {
 	method := os.Getenv("Http_Method")
 
 	if method == http.MethodPost {
+		payloadSecret, err := sdk.ReadSecret("payload-secret")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, err.Error())
+			os.Exit(1)
 
-		hmacErr := sdk.ValidHMAC(&req, "payload-secret", os.Getenv("Http_X_Cloud_Signature"))
+			return err.Error()
+		}
+
+		hmacErr := sdk.ValidHMAC(&req, payloadSecret, os.Getenv("Http_X_Cloud_Signature"))
 		if hmacErr != nil {
 			log.Printf("hmac error %s\n", hmacErr.Error())
 			os.Exit(1)

--- a/pipeline-log/handler.go
+++ b/pipeline-log/handler.go
@@ -22,7 +22,7 @@ func Handle(req []byte) string {
 
 	if method == http.MethodPost {
 
-		hmacErr := sdk.ValidHMAC(&req, "github-webhook-secret", os.Getenv("Http_X_Hub_Signature"))
+		hmacErr := sdk.ValidHMAC(&req, "payload-secret", os.Getenv("Http_X_Cloud_Signature"))
 		if hmacErr != nil {
 			log.Printf("hmac error %s\n", hmacErr.Error())
 			os.Exit(1)

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -129,7 +130,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/stack.yml
+++ b/stack.yml
@@ -6,7 +6,7 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: alexellis2/github-push:0.5.5
+    image: alexellis2/github-push:0.6.0
     labels:
       openfaas-cloud: "1"
     environment:
@@ -22,11 +22,28 @@ functions:
       - github.yml
     secrets:
       - github-webhook-secret
+      - payload-secret
+
+  github-event:
+    lang: go
+    handler: ./github-event
+    image: alexellis2/github-event:0.5.0
+    labels:
+      openfaas-cloud: "1"
+    environment:
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - github.yml
+      - gateway_config.yml
+    secrets:
+      - github-webhook-secret
+      - payload-secret
 
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: alexellis2/of-git-tar:0.7.4
+    image: alexellis2/of-git-tar:0.8.0
     labels:
       openfaas-cloud: "1"
     environment:
@@ -38,12 +55,12 @@ functions:
       - gateway_config.yml
       - github.yml
     secrets:
-      - github-webhook-secret
+      - payload-secret
 
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: alexellis2/of-buildshiprun:0.6.1
+    image: alexellis2/of-buildshiprun:0.7.0
     labels:
       openfaas-cloud: "1"
     environment:
@@ -58,8 +75,74 @@ functions:
     secrets:
       - basic-auth-user
       - basic-auth-password
-      - github-webhook-secret
+      - payload-secret
 #      - swarm-pull-secret
+
+  garbage-collect:
+    lang: go
+    handler: ./garbage-collect
+    image: alexellis2/garbage-collect:0.4.0
+    labels:
+      openfaas-cloud: "1"
+    environment:
+      write_debug: true
+      read_debug: true
+      read_timeout: 30s
+      write_timeout: 30s
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+      - payload-secret
+
+  github-status:
+    lang: go
+    handler: ./github-status
+    image: alexellis2/github-status:0.2.0
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+      validate_hmac: true
+      debug_token: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - private-key
+      - payload-secret
+
+  import-secrets:
+    lang: go
+    handler: ./import-secrets
+    image: alexellis2/import-secrets:0.3.0
+    labels:
+      openfaas-cloud: "1"
+    environment:
+      write_debug: true
+      read_debug: true
+      validate_hmac: true
+      combined_output: false
+    environment_file:
+      - github.yml
+    secrets:
+      - payload-secret
+
+  pipeline-log:
+    lang: go
+    handler: ./pipeline-log
+    image: alexellis2/pipeline-log:0.3.0
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - s3-access-key
+      - s3-secret-key
+      - payload-secret
 
   list-functions:
     lang: go
@@ -76,79 +159,6 @@ functions:
       - basic-auth-user
       - basic-auth-password
 
-  garbage-collect:
-    lang: go
-    handler: ./garbage-collect
-    image: alexellis2/garbage-collect:0.3.5
-    labels:
-      openfaas-cloud: "1"
-    environment:
-      write_debug: true
-      read_debug: true
-      read_timeout: 30s
-      write_timeout: 30s
-    environment_file:
-      - gateway_config.yml
-    secrets:
-      - basic-auth-user
-      - basic-auth-password
-
-  github-status:
-    lang: go
-    handler: ./github-status
-    image: alexellis2/github-status:0.1.4
-    environment:
-      write_debug: true
-      read_debug: true
-      combine_output: false
-      validate_hmac: true
-      debug_token: true
-    environment_file:
-      - gateway_config.yml
-      - github.yml
-    secrets:
-      - private-key
-      - github-webhook-secret
-
-  github-event:
-    lang: go
-    handler: ./github-event
-    image: alexellis2/github-event:0.4.5
-    labels:
-      openfaas-cloud: "1"
-    environment:
-      write_debug: true
-      read_debug: true
-    environment_file:
-      - github.yml
-      - gateway_config.yml
-    secrets:
-      - github-webhook-secret
-
-  import-secrets:
-    lang: go
-    handler: ./import-secrets
-    image: alexellis2/import-secrets:0.2.3
-    labels:
-      openfaas-cloud: "1"
-    environment:
-      write_debug: true
-      read_debug: true
-      validate_hmac: true
-      combined_output: false
-    environment_file:
-      - github.yml
-    secrets:
-      - github-webhook-secret
-
-  echo:
-    skip_build: true
-    image: functions/alpine:latest
-    fprocess: cat
-    environment:
-      write_debug: true
-      read_debug: true
-
   audit-event:
     lang: go
     handler: ./audit-event
@@ -158,17 +168,11 @@ functions:
     environment_file:
       - slack.yml
 
-  pipeline-log:
-    lang: go
-    handler: ./pipeline-log
-    image: alexellis2/pipeline-log:0.2.0
+  echo:
+    skip_build: true
+    image: functions/alpine:latest
+    fprocess: cat
     environment:
       write_debug: true
       read_debug: true
-      combine_output: false
-    environment_file:
-      - gateway_config.yml
-    secrets:
-      - s3-access-key
-      - s3-secret-key
-      - github-webhook-secret
+


### PR DESCRIPTION
## Description

Internal functions use payload-secret for trust, rather than
reusing the same key used for trust with GitHub.

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Build and unit tests. Deploying to e2e environment for further testing.

## Checklist:

I have:

- [x] updated the documentation if required

A new secret is required, see the diff. 

- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
