### PR TITLE
Add builder log url for failed build

### DIFF
--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -3,6 +3,8 @@ environment:
   gateway_url:  http://gateway.openfaas:8080/
   gateway_public_url: https://cloud.o6s.io/
   audit_url: http://gateway.openfaas:8080/function/audit-event
+  # Remove gateway_pretty_url if not using pretty URL
+  gateway_pretty_url: https://user.o6s.io/function
 
 # Security
   customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/github-status/handler.go
+++ b/github-status/handler.go
@@ -134,15 +134,15 @@ func buildPublicStatusURL(status string, statusContext string, event *sdk.Event)
 
 		if len(gatewayPrettyURL) > 0 {
 			url = strings.Replace(gatewayPrettyURL, "user", "system", 1)
-			url = strings.Replace(url, "function", "pipeline", 1)
+			url = strings.Replace(url, "function", "dashboard", 1)
 
 		} else if len(publicURL) > 0 {
 			if strings.HasSuffix(publicURL, "/") == false {
 				publicURL = publicURL + "/"
 			}
-			url = publicURL + "/function/system-pipeline"
+			url = publicURL + "/function/system-dashboard"
 		}
-		url += "?repoPath=" + event.Owner + "/" + event.Repository + "&commitSHA=" + event.SHA + "&function=" + event.Service
+		url += "/" + event.Owner + "/" + event.Service + "/log?repoPath=" + event.Owner + "/" + event.Repository + "&commitSHA=" + event.SHA
 	}
 
 	return url

--- a/github-status/handler.go
+++ b/github-status/handler.go
@@ -128,6 +128,21 @@ func buildPublicStatusURL(status string, statusContext string, event *sdk.Event)
 				url = publicURL
 			}
 		}
+	} else if status == sdk.StatusFailure {
+		publicURL := os.Getenv("gateway_public_url")
+		gatewayPrettyURL := os.Getenv("gateway_pretty_url")
+
+		if len(gatewayPrettyURL) > 0 {
+			url = strings.Replace(gatewayPrettyURL, "user", "system", 1)
+			url = strings.Replace(url, "function", "pipeline", 1)
+
+		} else if len(publicURL) > 0 {
+			if strings.HasSuffix(publicURL, "/") == false {
+				publicURL = publicURL + "/"
+			}
+			url = publicURL + "/function/system-pipeline"
+		}
+		url += "?repoPath=" + event.Owner + "/" + event.Repository + "&commitSHA=" + event.SHA + "&function=" + event.Service
 	}
 
 	return url


### PR DESCRIPTION
This commit adds builder pipeline log URL in github commit statues for
failed function build.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

