### PR TITLE
Report status to github Checks API with logs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Select these OAuth permissions:
 
 - "Repository contents" read-only
 - "Commit statuses" read and write
+- "Checks" read and write
 
 * Now select only the "push" event.
 
@@ -50,7 +51,7 @@ Any account
 
 * Save the new app.
 
-* Now download the private key for your GitHub App which we will use later in the guide for allowing OpenFaaS Cloud to write to commit statuses when a build passes or fails.
+* Now download the private key for your GitHub App which we will use later in the guide for allowing OpenFaaS Cloud to write to Checks or Commit statuses when a build passes or fails.
 
 The GitHub app will deliver webhooks to your OpenFaaS Cloud instance every time code is pushed in a user's function repository. Make sure you provide the public URL for your OpenFaaS gateway to the GitHub app:
 

--- a/github-status/handler_test.go
+++ b/github-status/handler_test.go
@@ -356,3 +356,49 @@ func TestPrivateKey(t *testing.T) {
 		t.Errorf("validating private key path: watch %v got %v", expectedPath, privateKey)
 	}
 }
+
+func TestGetCheckRunTitle(t *testing.T) {
+	status := &sdk.CommitStatus{
+		Context:     sdk.StackContext,
+		Description: "deployed: kvuchkov-hello-go",
+		Status:      sdk.StatusSuccess,
+	}
+	title := getCheckRunTitle(status)
+	if *title != "Deploy to OpenFaas" {
+		t.Fatalf("Expected %s but got %s", "Deploy to OpenFaas", *title)
+	}
+
+	status.Context = sdk.BuildFunctionContext("hello-go")
+	title = getCheckRunTitle(status)
+	if *title != "Build hello-go" {
+		t.Fatalf("Expected %s but got %s", "Build hello-go", *title)
+	}
+}
+
+func TestGetCheckRunStatus(t *testing.T) {
+	status := sdk.StatusFailure
+	checkStatus := getCheckRunStatus(&status)
+	if checkStatus != "completed" {
+		t.Fatalf("Expected %s, got %s", "completed", checkStatus)
+	}
+
+	status = sdk.StatusSuccess
+	checkStatus = getCheckRunStatus(&status)
+	if checkStatus != "completed" {
+		t.Fatalf("Expected %s, got %s", "completed", checkStatus)
+	}
+
+	status = sdk.StatusPending
+	checkStatus = getCheckRunStatus(&status)
+	if checkStatus != "queued" {
+		t.Fatalf("Expected %s, got %s", "queued", checkStatus)
+	}
+}
+
+func TestFormatLogs(t *testing.T) {
+	logs := "  		"
+	formatted := formatLogs(&logs)
+	if formatted != nil {
+		t.Fatalf("Empty logs shoud produce null formatted text")
+	}
+}

--- a/stack.yml
+++ b/stack.yml
@@ -107,7 +107,7 @@ functions:
   github-status:
     lang: go
     handler: ./github-status
-    image: functions/github-status:0.2.2
+    image: functions/github-status:0.3.0
     labels:
       role: openfaas-system
     environment:


### PR DESCRIPTION
github-status function is already coupled with github. Github offer a much richer API than the Status API. Checks API allows to provide rich information about a perticular status directly in the github UI, making it much more easier for developers to look through logs and pull requests for functions.

Now statuses are reported with additional details - the build logs.

The change is contained within the github-status function and is abstracted away from the rest of the openfaas-cloud.

Signed-off-by: Kiril Vuchkov <kirilvuchkov@gmail.com>

## Description

This is implementation for issue #107 Report status to Github via Checks API.

**Note that this requires build & push of "github-status" function after merge, b/c the version of the image is changed.**

## How Has This Been Tested?
I have a repo https://github.com/kvuchkov/test-github-app1 with 2 go functions that I used for development and testing.

Tried the following scenarios:
* Breaking 1/2 function 
* Fixing both functions
* Breaking both functions

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests