### PR TITLE
Add configuration for bucket name and secured TLS connection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -307,9 +307,9 @@ ACCESS_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
 
 * If you'd prefer to use an S3 Bucket hosted on AWS
 
-> Generate access key by using the security credentials page. Expand the Access Keys section, and then Create New Root Key.
+> Generate an access key by using the security credentials page. Expand the Access Keys section, and then Create New Root Key.
 
-> Generate secret key by opening the IAM console. Choose Users in the Details pane, pick the IAM user which will use the keys, and then Create Access Key on the Security Credentials tab.
+> Generate an secret key by opening the IAM console. Choose Users in the Details pane, pick the IAM user which will use the keys, and then Create Access Key on the Security Credentials tab.
 
 ```
 SECRET_KEY=access_key_here

--- a/docs/README.md
+++ b/docs/README.md
@@ -298,13 +298,22 @@ Logs from the container builder are stored in S3. This can be Minio which is S3-
 
 You can disable Log storage by commenting out the pipeline-log function from `stack.yml`.
 
-> Note: AWS S3 needs an additional two flags to be implemented to make sure TLS and a custom bucket name are used.
-
 * Generate secrets for Minio
 
 ```
 SECRET_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
 ACCESS_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+```
+
+* If you'd prefer to use an S3 Bucket hosted on AWS
+
+> Generate access key by using the security credentials page. Expand the Access Keys section, and then Create New Root Key.
+
+> Generate secret key by opening the IAM console. Choose Users in the Details pane, pick the IAM user which will use the keys, and then Create Access Key on the Security Credentials tab.
+
+```
+SECRET_KEY=access_key_here
+ACCESS_KEY=secret_key_here
 ```
 
 #### Kubernetes
@@ -354,9 +363,20 @@ docker service create --constraint="node.role==manager" \
 minio/minio:latest server /export
 ```
 
-Enter the value of the DNS above into `s3_url` in `gateway_config.yml` adding the port at the end:`minio:9000`
+Minio: 
+
+* Enter the value of the DNS above into `s3_url` in `gateway_config.yml` adding the port at the end:`minio:9000`
 
 > Note: For debugging and testing. You can expose the port of Minio with `docker service update minio --publish-add 9000:9000`, but this is not recommended on the public internet.
+
+AWS S3:
+
+* Enter the value of the DNS `s3.amazonaws.com` into `s3_url` in `gateway_config.yml`
+
+* In the same file set `s3_tls: true` and `s3_bucket` to the bucket you created in S3 like `s3_bucket: example-bucket`
+
+* Update the `s3_region` value such as : `s3_region: us-east-1`
+
 
 See https://docs.minio.io/docs/minio-quickstart-guide
 

--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -10,6 +10,8 @@ environment:
   builder_url: http://of-builder.openfaas:8080/
   s3_url: cloud-minio.openfaas.svc.cluster.local:9000
   s3_region: us-east-1
+  s3_tls: false
+  s3_bucket: pipeline
 
 # To use a shared Docker Hub account.
 #  repository_url: docker.io/ofcommunity/

--- a/pipeline-log/handler.go
+++ b/pipeline-log/handler.go
@@ -26,7 +26,7 @@ func Handle(req []byte) string {
 		}
 	}
 
-	region := os.Getenv("s3_region")
+	region := regionName()
 
 	bucketName := bucketName()
 
@@ -120,4 +120,12 @@ func bucketName() string {
 		log.Printf("Bucket name not found, set to default: %v\n", bucketName)
 	}
 	return bucketName
+}
+
+func regionName() string {
+	regionName, exist := os.LookupEnv("s3_region")
+	if exist == false || len(regionName) == 0 {
+		regionName = "us-east-1"
+	}
+	return regionName
 }

--- a/pipeline-log/handler_test.go
+++ b/pipeline-log/handler_test.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"os"
 	"testing"
 
 	"github.com/openfaas/openfaas-cloud/sdk"
@@ -16,5 +17,62 @@ func Test_getPath(t *testing.T) {
 	if got != want {
 		t.Errorf("got: %s, but want: %s", got, want)
 		t.Fail()
+	}
+}
+
+func Test_tlsEnabled(t *testing.T) {
+	connection := []struct {
+		title         string
+		value         string
+		expectedValue bool
+	}{
+		{
+			title:         "Connection enabled",
+			value:         "true",
+			expectedValue: true,
+		},
+		{
+			title:         "Connection enabled",
+			value:         "1",
+			expectedValue: true,
+		},
+		{
+			title:         "Connection disabled",
+			value:         "every other case is disabled",
+			expectedValue: false,
+		},
+	}
+	for _, test := range connection {
+		os.Setenv("s3_tls", test.value)
+		secured := tlsEnabled()
+		if secured != test.expectedValue {
+			t.Fatalf("Expected: %v got :%v.\n", test.expectedValue, secured)
+		}
+	}
+}
+
+func Test_bucketName(t *testing.T) {
+	bucketNames := []struct {
+		title         string
+		value         string
+		expectedValue string
+	}{
+		{
+			title:         "Bucket name env-var is present",
+			value:         "example-name",
+			expectedValue: "example-name",
+		},
+		{
+			title:         "Bucket name when env-var does not exist/unset",
+			value:         "",
+			expectedValue: "pipeline",
+		},
+	}
+	for _, test := range bucketNames {
+		os.Setenv("s3_bucket", test.value)
+		bucketName := bucketName()
+		if bucketName != test.expectedValue {
+			t.Errorf("Unexpected bucket name wanted: `%v` got: `%v`", test.expectedValue, bucketName)
+		}
 	}
 }

--- a/pipeline-log/handler_test.go
+++ b/pipeline-log/handler_test.go
@@ -76,3 +76,29 @@ func Test_bucketName(t *testing.T) {
 		}
 	}
 }
+func Test_regionName(t *testing.T) {
+	values := []struct {
+		title         string
+		value         string
+		expectedValue string
+	}{
+		{
+			title:         "Region name is set",
+			value:         "eu-west-3",
+			expectedValue: "eu-west-3",
+		},
+		{
+			title:         "Region name unset",
+			value:         "",
+			expectedValue: "us-east-1",
+		},
+	}
+	for _, test := range values {
+		os.Setenv("s3_region", test.value)
+		regionName := regionName()
+		if regionName != test.expectedValue {
+			t.Errorf("Expected region name: `%v` got: `%v`\n", test.expectedValue, regionName)
+		}
+	}
+
+}


### PR DESCRIPTION
Add two environmental variables bucket_name and
secure_connection which enable customisation by default
connection is false and bucket name is pipeline

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Added two environmental variables `s3_bucket` default set to `pipeline` and `s3_tls` default set to false in `gateway_config.yml` to enable customisation which are handled in pipeline-log function.

Closes #116 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With @bartsmykla help I was able to have S3 bucket named `openfaas-martin` and added a little tweak to the code that I removed from the PR so the `pipeline-logs` logs show the variables.

Working case:
set `pipeline-log` variables in stack.yml like so 
```
  pipeline-log:
    lang: go
    handler: ./pipeline-log
    image: martindekov/pipeline-log:0.3.1
    environment:
      write_debug: true
      read_debug: true
      combine_output: false
      secure_connection: false #new variable
      bucket_name: openfaas-martin #new variable
    environment_file:
      - gateway_config.yml
    secrets:
      - s3-access-key
      - s3-secret-key
      - payload-secret
```
Pushing function gocloudrepo triggered `pipeline-log` with following logs(the little tweaks mentioned above)
```
...
pipeline-log.1.zbfkocxb54va@FaasSwarm    | 2018/09/04 14:21:58 stderr: 2018/09/04 14:21:58 Bucket name is set to openfaas-martin
pipeline-log.1.zbfkocxb54va@FaasSwarm    | 2018/09/04 14:21:58 endpoint is s3.amazonaws.com
...
```
and the log was loaded into the `openfaas-martin` bucket in S3 as a folder with the name of my function-`gocloudfunc`

Second case comment out bucketname like
```
  pipeline-log:
...
      #bucket_name: openfaas-martin
...
```
The logs show 
```
...
pipeline-log.1.1k9hzriyp9db@FaasSwarm    | 2018/09/04 14:33:45 stderr: 2018/09/04 14:33:44 Bucket name not found, set to default: pipeline
pipeline-log.1.1k9hzriyp9db@FaasSwarm    | 2018/09/04 14:33:44 Bucket name is set to pipeline
pipeline-log.1.1k9hzriyp9db@FaasSwarm    | 2018/09/04 14:33:44 endpoint is s3.amazonaws.com
pipeline-log.1.1k9hzriyp9db@FaasSwarm    | 2018/09/04 14:33:45 error writing: pipeline/martindekov/gocloudfunc/8e0ca7c3007b45c7ab426679c28a2c5189234fee/gocloudfunc/build.log, error: Access Denied
pipeline-log.1.1k9hzriyp9db@FaasSwarm    | 2018/09/04 14:33:45 Success=false, Error=exit status 1
pipeline-log.1.1k9hzriyp9db@FaasSwarm    | 2018/09/04 14:33:45 Out=
...
```
Since the bucket name was missing it fell back to the default one `pipeline` for minio cases and it failed to deploy my logs

Third case commented out  `secure_connection` so false by default and `bucket_name: openfaas-martin` 

```
  pipeline-log:
...
      #secure_connection: false #new variable
      bucket_name: openfaas-martin
...
```
so again the log was updated to the S3 bucket and showed in `system-pipeline`
```
...
pipeline-log.1.pg25xwj1npib@FaasSwarm    | 2018/09/04 15:05:27 stderr: 2018/09/04 15:05:26 Bucket name is set to openfaas-martin
pipeline-log.1.pg25xwj1npib@FaasSwarm    | 2018/09/04 15:05:26 endpoint is s3.amazonaws.com
pipeline-log.1.pg25xwj1npib@FaasSwarm    | 2018/09/04 15:05:27 Duration: 0.642165 seconds
pipeline-log.1.pg25xwj1npib@FaasSwarm    | Wrote 14215 bytes to openfaas-martin/martindekov/gocloudfunc/8e0ca7c3007b45c7ab426679c28a2c5189234fee/gocloudfunc/build.log
...
```

When I specify bucket that does not exists the logs show:
```
...
pipeline-log.1.nn64lfa44bw7@FaasSwarm    | 2018/09/05 09:14:56 stderr: 2018/09/05 09:14:56 error writing: watisgoinon/martindekov/gocloudfunc/b8f19b37d4a987c5c7864bb56bb653dd7872f259/gocloudfunc/build.log, error: The specified bucket does not exist

...
```

The commits are the same since I redeliver payload and the bucket is private so I cant paste it here.


## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests

