### PR TITLE
Add current timestamp if no vertex timestamp

### DIFF
--- a/of-builder/main.go
+++ b/of-builder/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/gorilla/mux"
@@ -168,10 +169,13 @@ func build(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 				if v.Completed != nil {
 					msg = fmt.Sprintf("v: %s %s %.2fs", v.Started, v.Name, v.Completed.Sub(*v.Started).Seconds())
 				} else {
-					startedVal := "(no timestamp available)"
+					var startedTime time.Time
 					if v.Started != nil {
-						startedVal = v.Started.String()
+						startedTime = *(v.Started)
+					} else {
+						startedTime = time.Now()
 					}
+					startedVal := startedTime.Format(time.RFC3339)
 					msg = fmt.Sprintf("v: %s %v", startedVal, v.Name)
 				}
 				build.Append(msg)


### PR DESCRIPTION
This commit adds current time as a format
```
2018-09-03 16:27:09.580093614 +0000 UTC
```
In case the vertex timestamp v.Started is not available

Signed-off-by: Swarvanu Sengupta <swarvanusg@gmail.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

