### PR TITLE
Created network policies for OpenFaaS Cloud

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -9,6 +9,7 @@ functions:
     image: functions/github-push:0.6.0
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       # Http_X_Github_Event: push
       validate_hmac: true
@@ -30,6 +31,7 @@ functions:
     image: functions/github-event:0.5.0
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       write_debug: true
       read_debug: true
@@ -46,6 +48,7 @@ functions:
     image: functions/of-git-tar:0.8.0
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       read_timeout: 15m
       write_timeout: 15m
@@ -65,6 +68,7 @@ functions:
     image: functions/of-buildshiprun:0.7.0
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       read_timeout: 5m
       write_timeout: 5m
@@ -86,6 +90,7 @@ functions:
     image: functions/garbage-collect:0.4.0
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       write_debug: true
       read_debug: true
@@ -102,6 +107,8 @@ functions:
     lang: go
     handler: ./github-status
     image: functions/github-status:0.2.1
+    labels:
+      role: openfaas-system
     environment:
       write_debug: true
       read_debug: true
@@ -121,6 +128,7 @@ functions:
     image: functions/import-secrets:0.3.0
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       write_debug: true
       read_debug: true
@@ -135,6 +143,8 @@ functions:
     lang: go
     handler: ./pipeline-log
     image: functions/pipeline-log:0.3.1
+    labels:
+      role: openfaas-system
     environment:
       write_debug: true
       read_debug: true
@@ -152,6 +162,7 @@ functions:
     image: functions/list-functions:0.4.4
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
     environment:
       write_debug: true
       read_debug: true

--- a/yaml/ns-openfaas-fn-net-policy.yml
+++ b/yaml/ns-openfaas-fn-net-policy.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openfaas-fn
+  namespace: openfaas-fn
+spec:
+  policyTypes:
+    - Ingress
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              role: openfaas-system
+
+        - podSelector:
+            matchLabels:
+              role: openfaas-system

--- a/yaml/ns-openfaas-net-policy.yml
+++ b/yaml/ns-openfaas-net-policy.yml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openfaas
+  namespace: openfaas
+spec:
+  policyTypes:
+    - Ingress
+  podSelector: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              role: openfaas-system


### PR DESCRIPTION
Closes https://github.com/openfaas/openfaas-cloud/issues/108

Signed-off-by: Bart Smykla (VMware) <bartek@smykla.com>

## Description

Network policies are created for openfaas
and openfaas-fn namespaces and they are allowing
network traffic from namespaces and pods with label
`role=openfaas-system`, so functions which are not
Cloud ones can't communicate with any pod from
openfaas or openfaas-fn namespaces.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have tested that installing OpenFaaS with Ingress Controller, NodePort and LoadBalancer with applying current Network Policies and trying to communicate between pods with deployed functions (from my functions to cloud functions inside namespace openfaas-fn, from my functions to openfaas root services [gateway etc.], from root services to my functions and from cloud functions to my functions). Additionally I have created pods in both namespaces just with CentOS in it and I have tried to communicate between them assigning and removing `openfaas-system` labels from them.
<!--- Include details of your testing environment, and the tests you ran to -->
EKS cluster with 2x t2.medium nodes
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

