### PR TITLE
Add node8-express-template to git-tar function

### DIFF
--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -45,6 +45,14 @@ func Handle(req []byte) []byte {
 		os.Exit(-1)
 	}
 
+	err = fetchTemplates(clonePath)
+	if err != nil {
+		log.Println("Error fetching templates ", err.Error())
+		status.AddStatus(sdk.StatusFailure, "fetchTemplates error : "+err.Error(), sdk.StackContext)
+		reportStatus(status)
+		os.Exit(-1)
+	}
+
 	var shrinkWrapPath string
 	shrinkWrapPath, err = shrinkwrap(pushEvent, clonePath)
 	if err != nil {

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -42,6 +42,25 @@ func parseYAML(pushEvent sdk.PushEvent, filePath string) (*stack.Services, error
 	return parsed, err
 }
 
+func fetchTemplates(filePath string) error {
+	templateRepos := []string{"https://github.com/openfaas/templates", "https://github.com/openfaas-incubator/node8-express-template.git"}
+
+	for _, repo := range templateRepos {
+		pullCmd := exec.Command("faas-cli", "template", "pull", repo)
+		pullCmd.Dir = filePath
+		err := pullCmd.Start()
+		if err != nil {
+			return fmt.Errorf("Failed to start faas-cli template pull: %t", err)
+		}
+		err = pullCmd.Wait()
+		if err != nil {
+			return fmt.Errorf("Failed to wait faas-cli template pull: %t", err)
+		}
+	}
+
+	return nil
+}
+
 func shrinkwrap(pushEvent sdk.PushEvent, filePath string) (string, error) {
 	buildCmd := exec.Command("faas-cli", "build", "-f", "stack.yml", "--shrinkwrap")
 	buildCmd.Dir = filePath

--- a/stack.yml
+++ b/stack.yml
@@ -43,7 +43,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.8.0
+    image: functions/of-git-tar:0.8.1
     labels:
       openfaas-cloud: "1"
     environment:


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

## Description
This explicitely adds a template fetching phase in `git-tar`.  It fetches the default template plus the `node8-express-template`. Since it doesn't make much sense to manage the repos externally, it is hard coded inside the `fetchTemplates` function.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since i do not have a OpenFaaS Cloud cluster locally to test with, I have only been able to invoke the `fetchTemplates` function directly from a local unit test and check that the default *and* node8-express-template has been successfully pulled.

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

