### PR TITLE
Revendor outdated openfaas-cloud sdk to the newest 0.5.7 version

### DIFF
--- a/audit-event/Gopkg.lock
+++ b/audit-event/Gopkg.lock
@@ -17,11 +17,11 @@
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
   revision = "2cf97d7c25701cc7333781d7b61dcdfbbee2e911"
-  version = "0.5.4"
+  version = "0.5.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d745c72bef8e768503a280b683a6d90591a2f6c75460d8a8b1b3cb9465265e8f"
+  inputs-digest = "c9c2df46f9369415bfbe04678fa109d96ca0cdbaa3edee8033f1d0aec27e8281"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/audit-event/Gopkg.toml
+++ b/audit-event/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
-  version = "0.5.4"
+  version = "0.5.7"
 
 [prune]
   go-tests = true

--- a/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/audit-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,12 +5,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
-
-	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -130,7 +129,7 @@ func (status *Status) Report(gateway string, hmacKey string) (string, error) {
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
 	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
+		httpReq.Header.Add("X-Hub-Signature", "sha1="+hex.EncodeToString(hash))
 	}
 
 	res, err := c.Do(httpReq)

--- a/buildshiprun/Gopkg.lock
+++ b/buildshiprun/Gopkg.lock
@@ -16,12 +16,12 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "2cf97d7c25701cc7333781d7b61dcdfbbee2e911"
-  version = "0.5.4"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "058b15931438e83c951b977688d5abfe2595966abd6c79b49b3110e2ad667db6"
+  inputs-digest = "08be72262146e62e3b41876c84a211f68e8e10f6a4d6846b562c887dc276f68a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/buildshiprun/Gopkg.toml
+++ b/buildshiprun/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
-  version = "0.5.4"
+  version = "0.5.7"
 
 [prune]
   go-tests = true

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
@@ -12,12 +12,18 @@ func PostAudit(auditEvent AuditEvent) {
 	c := http.Client{}
 	bytesOut, _ := json.Marshal(&auditEvent)
 	reader := bytes.NewBuffer(bytesOut)
+	auditURL := os.Getenv("audit_url")
 
-	req, _ := http.NewRequest(http.MethodPost, os.Getenv("audit_url"), reader)
+	if len(auditURL) == 0 {
+		log.Println("PostAudit invalid auditURL, empty string")
+		return
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, auditURL, reader)
 
 	res, err := c.Do(req)
 	if err != nil {
-		log.Println(err)
+		log.Println("PostAudit", err)
 		return
 	}
 	if res.Body != nil {

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/openfaas/faas/gateway/types"
+)
+
+const (
+	defaultPrivateKeyName  = "private-key"
+	defaultSecretMountPath = "/var/openfaas/secrets"
 )
 
 // AddBasicAuth to a request by reading secrets when available
@@ -27,4 +33,25 @@ func AddBasicAuth(req *http.Request) error {
 		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
 	return nil
+}
+
+func GetPrivateKeyPath() string {
+	// Private key name can be different from the default 'private-key'
+	// When providing a different name in the stack.yaml, user need to specify the name
+	// in github.yml as `private_key_filename: <user_private_key>`
+	privateKeyName := os.Getenv("private_key_filename")
+
+	if privateKeyName == "" {
+		privateKeyName = defaultPrivateKeyName
+	}
+
+	secretMountPath := os.Getenv("secret_mount_path")
+
+	if secretMountPath == "" {
+		secretMountPath = defaultSecretMountPath
+	}
+
+	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
+
+	return privateKeyPath
 }

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -1,20 +1,24 @@
 package sdk
 
 // PushEvent as received from GitHub
-type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Private  bool   `json:"private"`
+type PushEventInstallation struct {
+	ID int `json:"id"`
+}
 
-		Owner Owner `json:"owner"`
-	}
+type PushEventRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Private  bool   `json:"private"`
+
+	Owner Owner `json:"owner"`
+}
+
+type PushEvent struct {
+	Ref           string `json:"ref"`
+	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Installation  PushEventInstallation
 }
 
 // Owner is the owner of a GitHub repo

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
@@ -1,0 +1,20 @@
+package sdk
+
+type Audit interface {
+	Post(AuditEvent) error
+}
+
+type NilLogger struct {
+}
+
+func (l NilLogger) Post(auditEvent AuditEvent) error {
+	return nil
+}
+
+type AuditLogger struct {
+}
+
+func (l AuditLogger) Post(auditEvent AuditEvent) error {
+	PostAudit(auditEvent)
+	return nil
+}

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -5,11 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	hmac "github.com/alexellis/hmac"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
+
+	hmac "github.com/alexellis/hmac"
 )
 
 // github status constant
@@ -115,21 +116,16 @@ make sure combine_output is disabled for github-status`, token)
 }
 
 // Report send a status update to github-status function
-func (status *Status) Report(gateway string, hmacKey string) (string, error) {
+func (status *Status) Report(gateway string, payloadSecret string) (string, error) {
 	body, _ := status.Marshal()
-
-	var hash []byte
-	// sign with hmac key if set
-	if len(hmacKey) > 0 {
-		hash = hmac.Sign(body, []byte(hmacKey))
-	}
 
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
-	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
+	if len(payloadSecret) > 0 {
+		digest := hmac.Sign(body, []byte(payloadSecret))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(digest))
 	}
 
 	res, err := c.Do(httpReq)

--- a/git-tar/Gopkg.lock
+++ b/git-tar/Gopkg.lock
@@ -2,79 +2,57 @@
 
 
 [[projects]]
-  digest = "1:241812f3621162c2b1b5791ae74cf9d70b1867645dc8008b441404afbe772f8d"
   name = "github.com/alexellis/derek"
   packages = ["auth"]
-  pruneopts = "UT"
   revision = "f8c2d49fd14b3e913c56ad2bd37193775836e906"
   version = "0.6.1"
 
 [[projects]]
-  digest = "1:871b7cfa5fe18bfdbd4bf117c166c3cff8d3b61c8afe4e998b5b8ac0c160ca24"
   name = "github.com/alexellis/hmac"
   packages = ["."]
-  pruneopts = "UT"
   revision = "d5d71edd7bc74eb6ae4b99eccc6bda738435f43f"
   version = "1.2"
 
 [[projects]]
-  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
-  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:cb12bf73c4bbdf76b5ea487a551a6fc6f1c61dd7629c96d6f956f32f24832701"
   name = "github.com/openfaas/faas"
   packages = ["gateway/types"]
-  pruneopts = "UT"
   revision = "9c2f6dd2a4e2aac0b253b29cc031865b76802ed5"
   version = "0.9.0"
 
 [[projects]]
-  digest = "1:ad27d75d737c2b9a3f8ede08b706159ce8b2ace0b6e5f3209f5c100404cf3837"
   name = "github.com/openfaas/faas-cli"
   packages = [
     "schema",
-    "stack",
+    "stack"
   ]
-  pruneopts = "UT"
   revision = "517378c0441f296860f9906c25b4584d9a47d0cd"
   version = "0.6.20"
 
 [[projects]]
-  digest = "1:da7e951a1ff6b1faa30c43307570f8e0d5ff5ce7256af1cc7f38ad89616fa2ae"
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  pruneopts = "UT"
-  revision = "2c8b41d64582ad95d0c9d37bed8b2e60ef88b775"
-  version = "0.5.6"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [[projects]]
-  digest = "1:5b92d232e81c3e8eec282c92dcaa2e0e1ad3c23157be19a01b3e33f7e6e8d137"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
-  pruneopts = "UT"
   revision = "256dc444b735e061061cf46c809487313d5b0065"
 
 [[projects]]
-  digest = "1:35c04c23c8aef680782e117c67e29750453c92d11448da616d2e399887e5fc86"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = "UT"
   revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/alexellis/derek/auth",
-    "github.com/alexellis/hmac",
-    "github.com/openfaas/faas-cli/schema",
-    "github.com/openfaas/faas-cli/stack",
-    "github.com/openfaas/openfaas-cloud/sdk",
-  ]
+  inputs-digest = "938b5ea5ce6d68923a392ef927901e00e019864add6a5cf411eaf1973efdf722"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/git-tar/Gopkg.toml
+++ b/git-tar/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
-  version = "0.5.2"
+  version = "0.5.7"
 
 [[constraint]]
   name = "github.com/alexellis/hmac"

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
@@ -1,0 +1,10 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatServiceName(owner, functionName string) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(owner), functionName)
+}

--- a/github-event/Gopkg.lock
+++ b/github-event/Gopkg.lock
@@ -16,12 +16,12 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "2cf97d7c25701cc7333781d7b61dcdfbbee2e911"
-  version = "0.5.4"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d4cb894617900834bd09e624c2568fb82741488d7da8e4aa782745fd644e010d"
+  inputs-digest = "c68607d08d14cc58e1d793951bc894715cfeafe070442cb68ff558955da72835"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/github-event/Gopkg.toml
+++ b/github-event/Gopkg.toml
@@ -31,5 +31,5 @@
   unused-packages = true
 
 [[constraint]]
-  version = "0.5.4"
+  version = "0.5.7"
   name = "github.com/openfaas/openfaas-cloud"

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
@@ -12,12 +12,18 @@ func PostAudit(auditEvent AuditEvent) {
 	c := http.Client{}
 	bytesOut, _ := json.Marshal(&auditEvent)
 	reader := bytes.NewBuffer(bytesOut)
+	auditURL := os.Getenv("audit_url")
 
-	req, _ := http.NewRequest(http.MethodPost, os.Getenv("audit_url"), reader)
+	if len(auditURL) == 0 {
+		log.Println("PostAudit invalid auditURL, empty string")
+		return
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, auditURL, reader)
 
 	res, err := c.Do(req)
 	if err != nil {
-		log.Println(err)
+		log.Println("PostAudit", err)
 		return
 	}
 	if res.Body != nil {

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/openfaas/faas/gateway/types"
+)
+
+const (
+	defaultPrivateKeyName  = "private-key"
+	defaultSecretMountPath = "/var/openfaas/secrets"
 )
 
 // AddBasicAuth to a request by reading secrets when available
@@ -27,4 +33,25 @@ func AddBasicAuth(req *http.Request) error {
 		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
 	return nil
+}
+
+func GetPrivateKeyPath() string {
+	// Private key name can be different from the default 'private-key'
+	// When providing a different name in the stack.yaml, user need to specify the name
+	// in github.yml as `private_key_filename: <user_private_key>`
+	privateKeyName := os.Getenv("private_key_filename")
+
+	if privateKeyName == "" {
+		privateKeyName = defaultPrivateKeyName
+	}
+
+	secretMountPath := os.Getenv("secret_mount_path")
+
+	if secretMountPath == "" {
+		secretMountPath = defaultSecretMountPath
+	}
+
+	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
+
+	return privateKeyPath
 }

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -1,20 +1,24 @@
 package sdk
 
 // PushEvent as received from GitHub
-type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Private  bool   `json:"private"`
+type PushEventInstallation struct {
+	ID int `json:"id"`
+}
 
-		Owner Owner `json:"owner"`
-	}
+type PushEventRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Private  bool   `json:"private"`
+
+	Owner Owner `json:"owner"`
+}
+
+type PushEvent struct {
+	Ref           string `json:"ref"`
+	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Installation  PushEventInstallation
 }
 
 // Owner is the owner of a GitHub repo

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
@@ -1,0 +1,20 @@
+package sdk
+
+type Audit interface {
+	Post(AuditEvent) error
+}
+
+type NilLogger struct {
+}
+
+func (l NilLogger) Post(auditEvent AuditEvent) error {
+	return nil
+}
+
+type AuditLogger struct {
+}
+
+func (l AuditLogger) Post(auditEvent AuditEvent) error {
+	PostAudit(auditEvent)
+	return nil
+}

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
@@ -1,0 +1,10 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatServiceName(owner, functionName string) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(owner), functionName)
+}

--- a/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/github-event/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -116,21 +116,16 @@ make sure combine_output is disabled for github-status`, token)
 }
 
 // Report send a status update to github-status function
-func (status *Status) Report(gateway string, hmacKey string) (string, error) {
+func (status *Status) Report(gateway string, payloadSecret string) (string, error) {
 	body, _ := status.Marshal()
-
-	var hash []byte
-	// sign with hmac key if set
-	if len(hmacKey) > 0 {
-		hash = hmac.Sign(body, []byte(hmacKey))
-	}
 
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
-	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
+	if len(payloadSecret) > 0 {
+		digest := hmac.Sign(body, []byte(payloadSecret))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(digest))
 	}
 
 	res, err := c.Do(httpReq)

--- a/github-push/Gopkg.lock
+++ b/github-push/Gopkg.lock
@@ -16,12 +16,12 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "c6ee93341c53962d9edd5578dacc5b2e2e7bf1db"
-  version = "0.5.5"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d4cb894617900834bd09e624c2568fb82741488d7da8e4aa782745fd644e010d"
+  inputs-digest = "c68607d08d14cc58e1d793951bc894715cfeafe070442cb68ff558955da72835"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/github-push/Gopkg.toml
+++ b/github-push/Gopkg.toml
@@ -29,5 +29,5 @@
   unused-packages = true
 
 [[constraint]]
-  version = "0.5.4"
+  version = "0.5.7"
   name = "github.com/openfaas/openfaas-cloud"

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/openfaas/faas/gateway/types"
+)
+
+const (
+	defaultPrivateKeyName  = "private-key"
+	defaultSecretMountPath = "/var/openfaas/secrets"
 )
 
 // AddBasicAuth to a request by reading secrets when available
@@ -27,4 +33,25 @@ func AddBasicAuth(req *http.Request) error {
 		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
 	return nil
+}
+
+func GetPrivateKeyPath() string {
+	// Private key name can be different from the default 'private-key'
+	// When providing a different name in the stack.yaml, user need to specify the name
+	// in github.yml as `private_key_filename: <user_private_key>`
+	privateKeyName := os.Getenv("private_key_filename")
+
+	if privateKeyName == "" {
+		privateKeyName = defaultPrivateKeyName
+	}
+
+	secretMountPath := os.Getenv("secret_mount_path")
+
+	if secretMountPath == "" {
+		secretMountPath = defaultSecretMountPath
+	}
+
+	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
+
+	return privateKeyPath
 }

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -1,25 +1,24 @@
 package sdk
 
-import (
-	"fmt"
-	"strings"
-)
-
 // PushEvent as received from GitHub
-type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Private  bool   `json:"private"`
+type PushEventInstallation struct {
+	ID int `json:"id"`
+}
 
-		Owner Owner `json:"owner"`
-	}
+type PushEventRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Private  bool   `json:"private"`
+
+	Owner Owner `json:"owner"`
+}
+
+type PushEvent struct {
+	Ref           string `json:"ref"`
+	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Installation  PushEventInstallation
 }
 
 // Owner is the owner of a GitHub repo
@@ -56,8 +55,4 @@ func BuildEventFromPushEvent(pushEvent PushEvent) *Event {
 	info.InstallationID = pushEvent.Installation.ID
 
 	return &info
-}
-
-func ServiceName(userName, functionName string) string {
-	return fmt.Sprintf("%s-%s", strings.ToLower(userName), functionName)
 }

--- a/github-status/Gopkg.lock
+++ b/github-status/Gopkg.lock
@@ -49,8 +49,8 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "2cf97d7c25701cc7333781d7b61dcdfbbee2e911"
-  version = "0.5.4"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [[projects]]
   branch = "master"
@@ -87,6 +87,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "910255cded951f935a946b72314c68ce58af0e5dd0943c13763f01bc73328cd0"
+  inputs-digest = "e43cb9bafefdaa5d889830c660af9d5f5d1f2118d71b933feb862e1c4b8f5b5b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/github-status/Gopkg.toml
+++ b/github-status/Gopkg.toml
@@ -39,7 +39,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
-  version = "0.5.4"
+  version = "0.5.7"
 
 [prune]
   go-tests = true

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
@@ -12,12 +12,18 @@ func PostAudit(auditEvent AuditEvent) {
 	c := http.Client{}
 	bytesOut, _ := json.Marshal(&auditEvent)
 	reader := bytes.NewBuffer(bytesOut)
+	auditURL := os.Getenv("audit_url")
 
-	req, _ := http.NewRequest(http.MethodPost, os.Getenv("audit_url"), reader)
+	if len(auditURL) == 0 {
+		log.Println("PostAudit invalid auditURL, empty string")
+		return
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, auditURL, reader)
 
 	res, err := c.Do(req)
 	if err != nil {
-		log.Println(err)
+		log.Println("PostAudit", err)
 		return
 	}
 	if res.Body != nil {

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
@@ -1,0 +1,20 @@
+package sdk
+
+type Audit interface {
+	Post(AuditEvent) error
+}
+
+type NilLogger struct {
+}
+
+func (l NilLogger) Post(auditEvent AuditEvent) error {
+	return nil
+}
+
+type AuditLogger struct {
+}
+
+func (l AuditLogger) Post(auditEvent AuditEvent) error {
+	PostAudit(auditEvent)
+	return nil
+}

--- a/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/github-status/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -116,21 +116,16 @@ make sure combine_output is disabled for github-status`, token)
 }
 
 // Report send a status update to github-status function
-func (status *Status) Report(gateway string, hmacKey string) (string, error) {
+func (status *Status) Report(gateway string, payloadSecret string) (string, error) {
 	body, _ := status.Marshal()
-
-	var hash []byte
-	// sign with hmac key if set
-	if len(hmacKey) > 0 {
-		hash = hmac.Sign(body, []byte(hmacKey))
-	}
 
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
-	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
+	if len(payloadSecret) > 0 {
+		digest := hmac.Sign(body, []byte(payloadSecret))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(digest))
 	}
 
 	res, err := c.Do(httpReq)

--- a/import-secrets/Gopkg.lock
+++ b/import-secrets/Gopkg.lock
@@ -65,8 +65,8 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "07ad9ccaea796c2d03cd217d3f67b7ba67bd0e95"
-  version = "0.4.1"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [[projects]]
   name = "golang.org/x/crypto"
@@ -218,6 +218,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fb0205e09197cca694b65968d7119885937555d53b8827e4ab73cce9887ae6c9"
+  inputs-digest = "6b54ed779f1c6baeb183a2c081015b7229b751d3508ee559d1c973ad0cf6deb0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/import-secrets/Gopkg.toml
+++ b/import-secrets/Gopkg.toml
@@ -11,7 +11,7 @@
   name = "k8s.io/apimachinery"
 
 [[constraint]]
-  version = "0.4.1"
+  version = "0.5.7"
   name = "github.com/openfaas/openfaas-cloud"
 
 [prune]

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.lock
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.lock
@@ -2,14 +2,27 @@
 
 
 [[projects]]
+  digest = "1:871b7cfa5fe18bfdbd4bf117c166c3cff8d3b61c8afe4e998b5b8ac0c160ca24"
+  name = "github.com/alexellis/hmac"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d5d71edd7bc74eb6ae4b99eccc6bda738435f43f"
+  version = "1.2"
+
+[[projects]]
+  digest = "1:cb12bf73c4bbdf76b5ea487a551a6fc6f1c61dd7629c96d6f956f32f24832701"
   name = "github.com/openfaas/faas"
   packages = ["gateway/types"]
-  revision = "81334141832d6c4fc9b78e6b5e17e5330eca7606"
-  version = "0.8.2"
+  pruneopts = "UT"
+  revision = "c86de503c7a20a46645239b9b081e029b15bf69b"
+  version = "0.8.11"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a47be49e1ed501cca1024b2e2f6da3e8f2e24aa08479acb84e9d630a5c150956"
+  input-imports = [
+    "github.com/alexellis/hmac",
+    "github.com/openfaas/faas/gateway/types",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.toml
@@ -30,6 +30,9 @@
   unused-packages = true
 
 [[constraint]]
-  version = "0.8.2"
+  version = "0.8.10"
   name = "github.com/openfaas/faas"
 
+[[constraint]]
+  name = "github.com/alexellis/hmac"
+  version = "1.2.0"

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
@@ -12,12 +12,18 @@ func PostAudit(auditEvent AuditEvent) {
 	c := http.Client{}
 	bytesOut, _ := json.Marshal(&auditEvent)
 	reader := bytes.NewBuffer(bytesOut)
+	auditURL := os.Getenv("audit_url")
 
-	req, _ := http.NewRequest(http.MethodPost, os.Getenv("audit_url"), reader)
+	if len(auditURL) == 0 {
+		log.Println("PostAudit invalid auditURL, empty string")
+		return
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, auditURL, reader)
 
 	res, err := c.Do(req)
 	if err != nil {
-		log.Println(err)
+		log.Println("PostAudit", err)
 		return
 	}
 	if res.Body != nil {

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/openfaas/faas/gateway/types"
+)
+
+const (
+	defaultPrivateKeyName  = "private-key"
+	defaultSecretMountPath = "/var/openfaas/secrets"
 )
 
 // AddBasicAuth to a request by reading secrets when available
@@ -27,4 +33,25 @@ func AddBasicAuth(req *http.Request) error {
 		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
 	return nil
+}
+
+func GetPrivateKeyPath() string {
+	// Private key name can be different from the default 'private-key'
+	// When providing a different name in the stack.yaml, user need to specify the name
+	// in github.yml as `private_key_filename: <user_private_key>`
+	privateKeyName := os.Getenv("private_key_filename")
+
+	if privateKeyName == "" {
+		privateKeyName = defaultPrivateKeyName
+	}
+
+	secretMountPath := os.Getenv("secret_mount_path")
+
+	if secretMountPath == "" {
+		secretMountPath = defaultSecretMountPath
+	}
+
+	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
+
+	return privateKeyPath
 }

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/build.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/build.go
@@ -1,0 +1,9 @@
+package sdk
+
+// BuildResult represents a successful Docker build and
+// push operation to a remote registry
+type BuildResult struct {
+	Log       []string `json:"log"`
+	ImageName string   `json:"imageName"`
+	Status    string   `json:"status"`
+}

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -1,21 +1,30 @@
 package sdk
 
 // PushEvent as received from GitHub
+type PushEventInstallation struct {
+	ID int `json:"id"`
+}
+
+type PushEventRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Private  bool   `json:"private"`
+
+	Owner Owner `json:"owner"`
+}
+
 type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Owner    struct {
-			Login string `json:"login"`
-			Email string `json:"email"`
-		} `json:"owner"`
-	}
+	Ref           string `json:"ref"`
+	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Installation  PushEventInstallation
+}
+
+// Owner is the owner of a GitHub repo
+type Owner struct {
+	Login string `json:"login"`
+	Email string `json:"email"`
 }
 
 // Event info to pass/store events across functions
@@ -29,6 +38,7 @@ type Event struct {
 	InstallationID int               `json:"installationID"`
 	Environment    map[string]string `json:"environment"`
 	Secrets        []string          `json:"secrets"`
+	Private        bool              `json:"private"`
 }
 
 // BuildEventFromPushEvent function to build Event from PushEvent
@@ -38,8 +48,10 @@ func BuildEventFromPushEvent(pushEvent PushEvent) *Event {
 	info.Service = pushEvent.Repository.Name
 	info.Owner = pushEvent.Repository.Owner.Login
 	info.Repository = pushEvent.Repository.Name
-	info.SHA = pushEvent.AfterCommitID
 	info.URL = pushEvent.Repository.CloneURL
+	info.Private = pushEvent.Repository.Private
+
+	info.SHA = pushEvent.AfterCommitID
 	info.InstallationID = pushEvent.Installation.ID
 
 	return &info

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/hmac.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/hmac.go
@@ -1,0 +1,34 @@
+package sdk
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alexellis/hmac"
+)
+
+// HmacEnabled uses validate_hmac env-var to verify if the
+// feature is enabled
+func HmacEnabled() bool {
+	return os.Getenv("validate_hmac") == "1" || os.Getenv("validate_hmac") == "true"
+}
+
+// ValidHMAC returns an error if HMAC could not be validated or if
+// the signature could not be loaded.
+func ValidHMAC(payload *[]byte, secretKey string, digest string) error {
+	key, err := ReadSecret(secretKey)
+	if err != nil {
+		return fmt.Errorf("unable to load HMAC symmetric key, %s", err.Error())
+	}
+
+	return validHMACWithSecretKey(payload, key, digest)
+}
+
+func validHMACWithSecretKey(payload *[]byte, secretText string, digest string) error {
+	validated := hmac.Validate(*payload, digest, secretText)
+
+	if validated != nil {
+		return fmt.Errorf("unable to validate HMAC")
+	}
+	return nil
+}

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
@@ -1,0 +1,20 @@
+package sdk
+
+type Audit interface {
+	Post(AuditEvent) error
+}
+
+type NilLogger struct {
+}
+
+func (l NilLogger) Post(auditEvent AuditEvent) error {
+	return nil
+}
+
+type AuditLogger struct {
+}
+
+func (l AuditLogger) Post(auditEvent AuditEvent) error {
+	PostAudit(auditEvent)
+	return nil
+}

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/pipeline.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/pipeline.go
@@ -1,0 +1,11 @@
+package sdk
+
+// PipelineLog stores a log output from a given stage of
+// a pipeline such as the container builder
+type PipelineLog struct {
+	RepoPath  string
+	CommitSHA string
+	Function  string
+	Source    string
+	Data      string
+}

--- a/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
+++ b/import-secrets/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
@@ -1,0 +1,10 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatServiceName(owner, functionName string) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(owner), functionName)
+}

--- a/list-functions/Gopkg.lock
+++ b/list-functions/Gopkg.lock
@@ -16,12 +16,12 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "2cf97d7c25701cc7333781d7b61dcdfbbee2e911"
-  version = "0.5.4"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d745c72bef8e768503a280b683a6d90591a2f6c75460d8a8b1b3cb9465265e8f"
+  inputs-digest = "c9c2df46f9369415bfbe04678fa109d96ca0cdbaa3edee8033f1d0aec27e8281"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/list-functions/Gopkg.toml
+++ b/list-functions/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
-  version = "0.5.4"
+  version = "0.5.7"
 
 [prune]
   go-tests = true

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
@@ -12,12 +12,18 @@ func PostAudit(auditEvent AuditEvent) {
 	c := http.Client{}
 	bytesOut, _ := json.Marshal(&auditEvent)
 	reader := bytes.NewBuffer(bytesOut)
+	auditURL := os.Getenv("audit_url")
 
-	req, _ := http.NewRequest(http.MethodPost, os.Getenv("audit_url"), reader)
+	if len(auditURL) == 0 {
+		log.Println("PostAudit invalid auditURL, empty string")
+		return
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, auditURL, reader)
 
 	res, err := c.Do(req)
 	if err != nil {
-		log.Println(err)
+		log.Println("PostAudit", err)
 		return
 	}
 	if res.Body != nil {

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/openfaas/faas/gateway/types"
+)
+
+const (
+	defaultPrivateKeyName  = "private-key"
+	defaultSecretMountPath = "/var/openfaas/secrets"
 )
 
 // AddBasicAuth to a request by reading secrets when available
@@ -27,4 +33,25 @@ func AddBasicAuth(req *http.Request) error {
 		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
 	return nil
+}
+
+func GetPrivateKeyPath() string {
+	// Private key name can be different from the default 'private-key'
+	// When providing a different name in the stack.yaml, user need to specify the name
+	// in github.yml as `private_key_filename: <user_private_key>`
+	privateKeyName := os.Getenv("private_key_filename")
+
+	if privateKeyName == "" {
+		privateKeyName = defaultPrivateKeyName
+	}
+
+	secretMountPath := os.Getenv("secret_mount_path")
+
+	if secretMountPath == "" {
+		secretMountPath = defaultSecretMountPath
+	}
+
+	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
+
+	return privateKeyPath
 }

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -1,20 +1,24 @@
 package sdk
 
 // PushEvent as received from GitHub
-type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Private  bool   `json:"private"`
+type PushEventInstallation struct {
+	ID int `json:"id"`
+}
 
-		Owner Owner `json:"owner"`
-	}
+type PushEventRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Private  bool   `json:"private"`
+
+	Owner Owner `json:"owner"`
+}
+
+type PushEvent struct {
+	Ref           string `json:"ref"`
+	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Installation  PushEventInstallation
 }
 
 // Owner is the owner of a GitHub repo

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
@@ -1,0 +1,20 @@
+package sdk
+
+type Audit interface {
+	Post(AuditEvent) error
+}
+
+type NilLogger struct {
+}
+
+func (l NilLogger) Post(auditEvent AuditEvent) error {
+	return nil
+}
+
+type AuditLogger struct {
+}
+
+func (l AuditLogger) Post(auditEvent AuditEvent) error {
+	PostAudit(auditEvent)
+	return nil
+}

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
@@ -1,0 +1,10 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatServiceName(owner, functionName string) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(owner), functionName)
+}

--- a/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/list-functions/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -116,21 +116,16 @@ make sure combine_output is disabled for github-status`, token)
 }
 
 // Report send a status update to github-status function
-func (status *Status) Report(gateway string, hmacKey string) (string, error) {
+func (status *Status) Report(gateway string, payloadSecret string) (string, error) {
 	body, _ := status.Marshal()
-
-	var hash []byte
-	// sign with hmac key if set
-	if len(hmacKey) > 0 {
-		hash = hmac.Sign(body, []byte(hmacKey))
-	}
 
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
-	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
+	if len(payloadSecret) > 0 {
+		digest := hmac.Sign(body, []byte(payloadSecret))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(digest))
 	}
 
 	res, err := c.Do(httpReq)

--- a/pipeline-log/Gopkg.lock
+++ b/pipeline-log/Gopkg.lock
@@ -47,8 +47,8 @@
 [[projects]]
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
-  revision = "2cf97d7c25701cc7333781d7b61dcdfbbee2e911"
-  version = "0.5.4"
+  revision = "ce4622958b63a168c04393f6cd2e875fa5be0efe"
+  version = "0.5.7"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
@@ -109,6 +109,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4ddab2164e78ee2f1b3cb375d259094e26329d5ae95a8d7bf475a8293d66ad70"
+  inputs-digest = "1e0e8c1b596af379a1f9ad5acac8033a0894de5ff598ef30e381d1b6e8d862f5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pipeline-log/Gopkg.toml
+++ b/pipeline-log/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
-  version = "0.5.4"
+  version = "0.5.7"
 
 [prune]
   go-tests = true

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/audit.go
@@ -12,12 +12,18 @@ func PostAudit(auditEvent AuditEvent) {
 	c := http.Client{}
 	bytesOut, _ := json.Marshal(&auditEvent)
 	reader := bytes.NewBuffer(bytesOut)
+	auditURL := os.Getenv("audit_url")
 
-	req, _ := http.NewRequest(http.MethodPost, os.Getenv("audit_url"), reader)
+	if len(auditURL) == 0 {
+		log.Println("PostAudit invalid auditURL, empty string")
+		return
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, auditURL, reader)
 
 	res, err := c.Do(req)
 	if err != nil {
-		log.Println(err)
+		log.Println("PostAudit", err)
 		return
 	}
 	if res.Body != nil {

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/auth.go
@@ -4,8 +4,14 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	"github.com/openfaas/faas/gateway/types"
+)
+
+const (
+	defaultPrivateKeyName  = "private-key"
+	defaultSecretMountPath = "/var/openfaas/secrets"
 )
 
 // AddBasicAuth to a request by reading secrets when available
@@ -27,4 +33,25 @@ func AddBasicAuth(req *http.Request) error {
 		req.SetBasicAuth(credentials.User, credentials.Password)
 	}
 	return nil
+}
+
+func GetPrivateKeyPath() string {
+	// Private key name can be different from the default 'private-key'
+	// When providing a different name in the stack.yaml, user need to specify the name
+	// in github.yml as `private_key_filename: <user_private_key>`
+	privateKeyName := os.Getenv("private_key_filename")
+
+	if privateKeyName == "" {
+		privateKeyName = defaultPrivateKeyName
+	}
+
+	secretMountPath := os.Getenv("secret_mount_path")
+
+	if secretMountPath == "" {
+		secretMountPath = defaultSecretMountPath
+	}
+
+	privateKeyPath := filepath.Join(secretMountPath, privateKeyName)
+
+	return privateKeyPath
 }

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -1,20 +1,24 @@
 package sdk
 
 // PushEvent as received from GitHub
-type PushEvent struct {
-	Ref        string `json:"ref"`
-	Repository struct {
-		Name     string `json:"name"`
-		FullName string `json:"full_name"`
-		CloneURL string `json:"clone_url"`
-		Private  bool   `json:"private"`
+type PushEventInstallation struct {
+	ID int `json:"id"`
+}
 
-		Owner Owner `json:"owner"`
-	}
+type PushEventRepository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	CloneURL string `json:"clone_url"`
+	Private  bool   `json:"private"`
+
+	Owner Owner `json:"owner"`
+}
+
+type PushEvent struct {
+	Ref           string `json:"ref"`
+	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
-	Installation  struct {
-		ID int `json:"id"`
-	}
+	Installation  PushEventInstallation
 }
 
 // Owner is the owner of a GitHub repo

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/interfaces.go
@@ -1,0 +1,20 @@
+package sdk
+
+type Audit interface {
+	Post(AuditEvent) error
+}
+
+type NilLogger struct {
+}
+
+func (l NilLogger) Post(auditEvent AuditEvent) error {
+	return nil
+}
+
+type AuditLogger struct {
+}
+
+func (l AuditLogger) Post(auditEvent AuditEvent) error {
+	PostAudit(auditEvent)
+	return nil
+}

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/service.go
@@ -1,0 +1,10 @@
+package sdk
+
+import (
+	"fmt"
+	"strings"
+)
+
+func FormatServiceName(owner, functionName string) string {
+	return fmt.Sprintf("%s-%s", strings.ToLower(owner), functionName)
+}

--- a/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
+++ b/pipeline-log/vendor/github.com/openfaas/openfaas-cloud/sdk/status.go
@@ -116,21 +116,16 @@ make sure combine_output is disabled for github-status`, token)
 }
 
 // Report send a status update to github-status function
-func (status *Status) Report(gateway string, hmacKey string) (string, error) {
+func (status *Status) Report(gateway string, payloadSecret string) (string, error) {
 	body, _ := status.Marshal()
-
-	var hash []byte
-	// sign with hmac key if set
-	if len(hmacKey) > 0 {
-		hash = hmac.Sign(body, []byte(hmacKey))
-	}
 
 	c := http.Client{}
 	bodyReader := bytes.NewBuffer(body)
 	httpReq, _ := http.NewRequest(http.MethodPost, gateway+"function/github-status", bodyReader)
 
-	if len(hmacKey) > 0 {
-		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(hash))
+	if len(payloadSecret) > 0 {
+		digest := hmac.Sign(body, []byte(payloadSecret))
+		httpReq.Header.Add("X-Cloud-Signature", "sha1="+hex.EncodeToString(digest))
 	}
 
 	res, err := c.Do(httpReq)


### PR DESCRIPTION
Revendoring audit-event,buildshiprun,git-tar,github-event,
github-push,github-status,import-secrets,list-function and
pipeline-log with the newest 0.5.7 openfaas-cloud sdk

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Revendored the following functions with newest 0.5.7 sdk
* audit-event
* buildshiprun
* git-tar
* github-event
* github-push
* github-status
* import-secrets
* list-function 
* pipeline-log

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

