### PR TITLE
Fix function shortname

### DIFF
--- a/dashboard/overview/index.html
+++ b/dashboard/overview/index.html
@@ -119,6 +119,7 @@
                     return 0
                 });
 
+                var userPrefixRegex = new RegExp("^" + user + "-");
                 for(var i = 0; i < data.length; i++) {
                     var index = i;
                     var item = data[index];
@@ -126,10 +127,7 @@
                     var since = new Date(parseInt(item.labels["Git-DeployTime"])*1000);
                     var sinceDuration = moment(since).fromNow();
 
-                    var shortName = item.name;
-                    if(shortName.indexOf("-") > -1) {
-                        shortName = shortName.substr(shortName.indexOf("-") + 1);
-                    }
+                    var shortName = item.name.replace(userPrefixRegex, "");
 
                     var url;
                    

--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -9,7 +9,7 @@ functions:
   system-overview:
     lang: go
     handler: ./overview
-    image: alexellis2/overview:0.4.3
+    image: functions/overview:0.4.4
     environment:
       content_type: "text/html"
       combine_output: "false"
@@ -20,7 +20,7 @@ functions:
 
   system-list-functions:
     skip_build: true
-    image: alexellis2/list-functions:0.4.3
+    image: functions/list-functions:0.4.3
     fprocess: ./handler
     environment:
       gateway_url: http://gateway.openfaas:8080/
@@ -35,7 +35,7 @@ functions:
   system-pipeline:
     lang: go
     handler: ./pipeline
-    image: alexellis2/pipeline:0.1.0
+    image: functions/pipeline:0.1.0
     environment:
       content_type: "text/html"
       combine_output: "false"


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

## Description

This fixes the shortname of the function even though it includes a `-`.
It assumes the function `name` is always prefixed with the `user` and replaces that string.

Closes #150 

This fix also needs to be applied to #148 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since I don't have my own OpenFaaS Cloud cluster, I've only tested this as plain JavaScript (Unit test level)

```js
var user = "zhenfeng-zhu"
var name = "zhenfeng-zhu-hello-go";
var userPrefixRegex = new RegExp("^" + user + "-");
name.replace(userPrefixRegex, ""); // "hello-go"
```

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

