### PR TITLE
Move cloud front facing function to be github-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features:
 * Applies GitOps principles - GitHub is the single source of truth
 * To build and deploy a new version of a function - just push to your GitHub repo
 * Subscription to OpenFaaS Cloud is done via a single click using a GitHub App
-* Secured through HMAC - the public facing function "github-push" uses HMAC to verify the origin of events
+* Secured through HMAC - the public facing function "github-event" uses HMAC to verify the origin of events
 * HTTPS endpoint and build notifications for your commits
 
 ## Blog post
@@ -71,9 +71,13 @@ Read my [introducing OpenFaaS Cloud](https://blog.alexellis.io/introducing-openf
 
 OpenFaaS Cloud is built using OpenFaaS Golang functions to interact with GitHub and build/deploy your functions just seconds after your `git push`.
 
-* Function: github-push
+* Function: github-event
 
 Receives events from the GitHub app and checks the origin via HMAC
+
+* Function: github-push
+
+Handles push events from the "github-event" function
 
 * Function: git-tar
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,8 +52,12 @@ Any account
 
 * Now download the private key for your GitHub App which we will use later in the guide for allowing OpenFaaS Cloud to write to commit statuses when a build passes or fails.
 
-The GitHub app will deliver webhooks to your OpenFaaS Cloud instance every time code is pushed in a user's function repository. Make sure you provide the public URL for your OpenFaaS gateway to the GitHub app. Like:  
-`http://my.openfaas.cloud/function/github-push`
+The GitHub app will deliver webhooks to your OpenFaaS Cloud instance every time code is pushed in a user's function repository. Make sure you provide the public URL for your OpenFaaS gateway to the GitHub app:
+
+* With the router configured the URL should be like: `http://system.openfaas.cloud/github-event`
+
+* If you don't have the router configured remove the `system-` prefix from `system-github-event` in `stack.yml` and set the URL like: `http://my.openfaas.cloud/functions/github-event`
+
 
 ### Create an internal trust secret
 

--- a/stack.yml
+++ b/stack.yml
@@ -24,7 +24,7 @@ functions:
       - github-webhook-secret
       - payload-secret
 
-  github-event:
+  system-github-event:
     lang: go
     handler: ./github-event
     image: functions/github-event:0.5.0
@@ -32,6 +32,7 @@ functions:
       openfaas-cloud: "1"
       role: openfaas-system
     environment:
+      validate_hmac: true
       write_debug: true
       read_debug: true
     environment_file:


### PR DESCRIPTION
Replacing front facing function from github-push to
github-event which supports more events and alternating
documentation in certain places to direct to github-event
as the front facing function also adding validate_hmac
variable to the github-event which was missing

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Added `validate_hmac: true` to `stack.yml` in now named `system-github-event` function and alternated the documents to now reference to `github-event` as the front facing function also added explanation in case the `of-router` is not configured.

Note: Left description pointing to search logs in case you pushed to `github-push` since in that scenario the `github-event` only redirects the function. Can alternate that if required.

Closes #142 

##  How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On my of-cloud instance the `stack.yml` looks like
```
...
  system-github-event:
    lang: go
    handler: ./github-event
    image: functions/github-event:0.5.0
    labels:
      openfaas-cloud: "1"
    environment:
      validate_hmac: true
      write_debug: true
      read_debug: true
    environment_file:
      - github.yml
      - gateway_config.yml
    secrets:
      - github-webhook-secret
      - payload-secret
...
```
and the of-router configured to access functions to the following url
`http://martindekov.team-serverless.xyz:8080/<fn_name>`
set the webhook in github application to  send events to `http://martindekov.team-serverless.xyz:8080/github-event` and `validate_hmac: true` to successfully recieve commit/remove/install
events from github.
## Checklist:

I have:

- [x] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

