### PR TITLE
Force scaling limits. Make them configurable

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -144,6 +144,14 @@ func Handle(req []byte) string {
 		if len(defaultMemoryLimit) == 0 {
 			defaultMemoryLimit = "20m"
 		}
+		scalingMinLimit := os.Getenv("scaling_min_limit")
+		if len(defaultMemoryLimit) == 0 {
+			scalingMinLimit = "1"
+		}
+		scalingMaxLimit := os.Getenv("scaling_max_limit")
+		if len(defaultMemoryLimit) == 0 {
+			scalingMaxLimit = "4"
+		}
 
 		readOnlyRootFS := getReadOnlyRootFS()
 
@@ -161,6 +169,8 @@ func Handle(req []byte) string {
 				"Git-SHA":        event.SHA,
 				"faas_function":  serviceValue,
 				"app":            serviceValue,
+				"com.openfaas.scale.min": scalingMinLimit,
+				"com.openfaas.scale.max": scalingMaxLimit,
 			},
 			Limits: Limits{
 				Memory: defaultMemoryLimit,

--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -13,6 +13,8 @@ environment:
   s3_tls: false
   s3_bucket: pipeline
   readonly_root_filesystem: true
+  scaling_min_limit: 1
+  scaling_max_limit: 4
 
 # To use a shared Docker Hub account.
 #  repository_url: docker.io/ofcommunity/


### PR DESCRIPTION
With this change buildshiprun command applies scaling limits to
the deployment. The default values are set to 1 for min and
4 for max. They are configurable in the `gateway_config.yml`

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Resolves #154

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After deployment the labels are available in 
```
{  
   "name":"ivanayov-hello-wrold",
   "image":"ivanayov/ivanayov-faas-cloud-test-hello-wrold:latest-dffc797",
   "invocationCount":0,
   "replicas":1,
   "envProcess":"",
   "availableReplicas":1,
   "labels":{  
      "Git-Cloud":"1",
      "Git-DeployTime":"1536599218",
      "Git-Owner":"ivanayov",
      "Git-Repo":"faas-cloud-test",
      "Git-SHA":"dffc79772e100bee742b4584752165c2885c9e86",
      "app":"ivanayov-hello-wrold",
      "com.openfaas.function":"ivanayov-hello-wrold",
      "com.openfaas.scale.max":"4",
      "com.openfaas.scale.min":"1",
      "com.openfaas.uid":"859184577",
      "faas_function":"ivanayov-hello-wrold",
      "function":"true"
   },
   "annotations":null
}
```

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
