### PR TITLE
Fix buildshiprun scaling limits defaults

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -142,14 +142,8 @@ func Handle(req []byte) string {
 
 		defaultMemoryLimit := getMemoryLimit()
 
-		scalingMinLimit := os.Getenv("scaling_min_limit")
-		if len(defaultMemoryLimit) == 0 {
-			scalingMinLimit = "1"
-		}
-		scalingMaxLimit := os.Getenv("scaling_max_limit")
-		if len(defaultMemoryLimit) == 0 {
-			scalingMaxLimit = "4"
-		}
+		scalingMinLimit := getConfig("scaling_min_limit", "1")
+		scalingMaxLimit := getConfig("scaling_max_limit", "4")
 
 		readOnlyRootFS := getReadOnlyRootFS()
 
@@ -202,6 +196,15 @@ func Handle(req []byte) string {
 	status.AddStatus(sdk.StatusSuccess, fmt.Sprintf("deployed: %s", serviceValue), sdk.BuildFunctionContext(event.Service))
 	reportStatus(status)
 	return fmt.Sprintf("buildStatus %s %s", imageName, res.Status)
+}
+
+func getConfig(key string, defaultValue string) string {
+
+	res := os.Getenv(key)
+	if len(res) == 0 {
+		res = defaultValue
+	}
+	return res
 }
 
 // createPipelineLog sends a log to pipeline-log and will

--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -175,7 +175,6 @@ func Test_getReadOnlyRootFS_override(t *testing.T) {
 		t.Fail()
 	}
 }
-
 func Test_getMemoryLimit_Swarm(t *testing.T) {
 	tests := []struct {
 		title         string
@@ -277,4 +276,49 @@ func Test_existingVariable_nonExistent(t *testing.T) {
 			t.Errorf("Should be:`%v` got:`%v`", expectedBool, exist)
 		}
 	})
+}
+
+func Test_getConfig(t *testing.T) {
+
+	var configOpts = []struct {
+		name         string
+		value        string
+		defaultValue string
+		isConfugured bool
+	}{
+		{
+			name:         "scaling_max_limit",
+			value:        "",
+			defaultValue: "4",
+			isConfugured: true,
+		},
+		{
+			name:         "scaling_max_limit",
+			value:        "10",
+			defaultValue: "4",
+			isConfugured: true,
+		},
+		{
+			name:         "random_config",
+			value:        "",
+			defaultValue: "18",
+			isConfugured: false,
+		},
+	}
+	for _, config := range configOpts {
+		t.Run(config.name, func(t *testing.T) {
+			if config.isConfugured {
+				os.Setenv(config.name, config.value)
+			}
+			value := getConfig(config.name, config.defaultValue)
+			want := config.defaultValue
+			if len(config.value) > 0 {
+				want = config.value
+			}
+
+			if value != want {
+				t.Errorf("want %s, but got %s", want, value)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This fixes buildshiprun handler to set properly default values
for min and max scailing limits. Adds test coverage of how configuration is loaded

Follows up pull #157

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>