### PR TITLE
Fixes #169

### DIFF
--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -1,4 +1,4 @@
 .PHONY: build
 
 build:
-	(cd client; yarn; yarn run build)
+	( docker run -v $(shell pwd):/dashboard node:8-alpine /bin/sh -c "cd dashboard/client && yarn && yarn run build")


### PR DESCRIPTION
Use node:8-alpine container

Signed-off-by: Jakub Krol <jakub.krol@poczta.fm>

## Description
I switched the command in make to `docker run` command executing building inside official Nodejs container.

## How Has This Been Tested?
I have run `make` command inside dashboard directory

## Checklist:

I have:
- [ x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x ] signed-off my commits with `git commit -s`

