### PR TITLE
Add constant for 'X-Cloud-Signature' to sdk

### DIFF
--- a/sdk/constants.go
+++ b/sdk/constants.go
@@ -1,0 +1,6 @@
+package sdk
+
+const (
+	//CloudSignatureHeader header name to pass signed payload secret
+	CloudSignatureHeader = "X-Cloud-Signature"
+)


### PR DESCRIPTION
This commit adds a constant to sdk for 'X-Cloud-Signature' header name.

Fixes first part of #167 

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

I have:

- [ ] updated the documentation if required
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

