### PR TITLE
Add golang-http-template in git-tar templates

### DIFF
--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -43,7 +43,7 @@ func parseYAML(pushEvent sdk.PushEvent, filePath string) (*stack.Services, error
 }
 
 func fetchTemplates(filePath string) error {
-	templateRepos := []string{"https://github.com/openfaas/templates", "https://github.com/openfaas-incubator/node8-express-template.git"}
+	templateRepos := []string{"https://github.com/openfaas/templates", "https://github.com/openfaas-incubator/node8-express-template.git", "https://github.com/openfaas-incubator/golang-http-template.git"}
 
 	for _, repo := range templateRepos {
 		pullCmd := exec.Command("faas-cli", "template", "pull", repo)


### PR DESCRIPTION
Adding golang-http-template as another template
to be fetched in through git-tar

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Adding `https://github.com/openfaas-incubator/golang-http-template.git` to be cloned through faas-cli in `git-tar`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## Checklist:

I have:

- [ ] updated the documentation if required
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

