### PR TITLE
Increase the default memory limit to 128 mb

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -465,7 +465,7 @@ func getMemoryLimit() string {
 	}
 
 	if len(memoryLimit) == 0 {
-		memoryLimit = "20" + suffix
+		memoryLimit = "128" + suffix
 	} else {
 		memoryLimit = memoryLimit + suffix
 	}


### PR DESCRIPTION
Increasing the default memory limit of buildshiprun
in case the env-var is missing to be 128 mb

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

The default memory limit of buildshiprun was 20 mb in case the environmental variable is missing, now its 128 mb

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

N.A.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
