### PR TITLE
Format gateway url depending on env var

### DIFF
--- a/sdk/service.go
+++ b/sdk/service.go
@@ -8,3 +8,17 @@ import (
 func FormatServiceName(owner, functionName string) string {
 	return fmt.Sprintf("%s-%s", strings.ToLower(owner), functionName)
 }
+
+func CreateServiceURL(URL, suffix string) string {
+	if len(suffix) == 0 {
+		return URL
+	}
+	columns := strings.Count(URL, ":")
+	//columns in URL with port are 2 i.e. http://url:port
+	if columns == 2 {
+		baseURL := URL[:strings.LastIndex(URL, ":")]
+		port := URL[strings.LastIndex(URL, ":"):]
+		return fmt.Sprintf("%s.%s%s", baseURL, suffix, port)
+	}
+	return fmt.Sprintf("%s.%s", URL, suffix)
+}

--- a/sdk/service_test.go
+++ b/sdk/service_test.go
@@ -38,3 +38,45 @@ func Test_FormatServiceName(t *testing.T) {
 		}
 	}
 }
+
+func Test_CreateServiceURL(t *testing.T) {
+	tests := []struct {
+		title       string
+		URL         string
+		suffix      string
+		expectedURL string
+	}{
+		{
+			title:       "URL formatted for Swarm with port",
+			URL:         "http://gateway:8080",
+			suffix:      "",
+			expectedURL: "http://gateway:8080",
+		},
+		{
+			title:       "URL formatted for Kubernetes",
+			URL:         "http://gateway:8080",
+			suffix:      "openfaas",
+			expectedURL: "http://gateway.openfaas:8080",
+		},
+		{
+			title:       "URL formatted for Swarm without port",
+			URL:         "http://gateway",
+			suffix:      "",
+			expectedURL: "http://gateway",
+		},
+		{
+			title:       "URL formatted for Kubernetes without port",
+			URL:         "http://gateway",
+			suffix:      "openfaas",
+			expectedURL: "http://gateway.openfaas",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			URL := CreateServiceURL(test.URL, test.suffix)
+			if URL != test.expectedURL {
+				t.Errorf("Expected: `%v` got: `%v`", test.expectedURL, URL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Creating a function in sdk which handles the formating of the
internal gateway URL. If variable present for kubernetes
the namespace is appended to the URL

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

The gateway will be formated depending the environmental variable `dns_suffix` placed in `gateway_config.yml` rather than manually go around all the places `.openfaas` for example is mentioned.

In code is used like 
```
  suffix := os.Getenv("dns_suffix")
  builderURL := os.Getenv("builder_url")
  gatewayURL := os.Getenv("gateway_url")
  builderURL = sdk.CreateServiceURL(builderURL, suffix)
  gatewayURL = sdk.CreateServiceURL(gatewayURL, suffix)
```

Once we have this re-vendored in all the functions I can move forward with updating the Documentation and all the functions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on Swarm and Kubernetes with one function `buildshiprun` and environmental variable `dns_suffix: openfaas` commented out(for Swarm) and non-commented out(for Kubernetes). The URL is built as it should and functions are built through `buildshiprun` as they should.

## How are existing users impacted? What migration steps/scripts do we need?

N.A. This feature wont affect anyone with instances of the cloud running.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
