### PR TITLE
[WIP] Edit timestamp format for of-builder logs

### DIFF
--- a/of-builder/main.go
+++ b/of-builder/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/gorilla/mux"
@@ -168,10 +169,13 @@ func build(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 				if v.Completed != nil {
 					msg = fmt.Sprintf("v: %s %s %.2fs", v.Started, v.Name, v.Completed.Sub(*v.Started).Seconds())
 				} else {
-					startedVal := "(no timestamp available)"
+					var startedTime time.Time
 					if v.Started != nil {
-						startedVal = v.Started.String()
+						startedTime = *(v.Started)
+					} else {
+						startedTime = time.Now()
 					}
+					startedVal := startedTime.Format(time.RFC3339)
 					msg = fmt.Sprintf("v: %s %v", startedVal, v.Name)
 				}
 				build.Append(msg)

--- a/of-builder/main.go
+++ b/of-builder/main.go
@@ -167,7 +167,7 @@ func build(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 			for _, v := range s.Vertexes {
 				var msg string
 				if v.Completed != nil {
-					msg = fmt.Sprintf("v: %s %s %.2fs", v.Started, v.Name, v.Completed.Sub(*v.Started).Seconds())
+					msg = fmt.Sprintf("v: %s %s %.2fs", v.Started.Format(time.RFC3339), v.Name, v.Completed.Sub(*v.Started).Seconds())
 				} else {
 					var startedTime time.Time
 					if v.Started != nil {
@@ -183,14 +183,14 @@ func build(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 
 			}
 			for _, s := range s.Statuses {
-				msg := fmt.Sprintf("s: %s %s %d", s.Timestamp, s.ID, s.Current)
+				msg := fmt.Sprintf("s: %s %s %d", s.Timestamp.Format(time.RFC3339), s.ID, s.Current)
 				build.Append(msg)
 
 				fmt.Printf("status: %s %s %d\n", s.Vertex, s.ID, s.Current)
 			}
 			for _, l := range s.Logs {
 
-				msg := fmt.Sprintf("l: %s %s", l.Timestamp, l.Data)
+				msg := fmt.Sprintf("l: %s %s", l.Timestamp.Format(time.RFC3339), l.Data)
 				build.Append(msg)
 
 				fmt.Printf("log: %s\n%s\n", l.Vertex, l.Data)


### PR DESCRIPTION
## Description

This follows up #127 with adding `time.RFC3339` format for all
timestamps printed in the of-builder logs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In progress

## How are existing users impacted? What migration steps/scripts do we need?



## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
