### PR TITLE
copy badge markdown to clipboard

### DIFF
--- a/dashboard/client/package.json
+++ b/dashboard/client/package.json
@@ -12,6 +12,7 @@
     "react": "^16.4.2",
     "react-ace": "^6.1.4",
     "react-bootstrap": "^0.32.4",
+    "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.4.2",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.5"

--- a/dashboard/client/src/pages/FunctionDetailPage.js
+++ b/dashboard/client/src/pages/FunctionDetailPage.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import queryString from 'query-string';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link } from 'react-router-dom';
+import { Modal, Form, Well } from 'react-bootstrap';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { functionsApi } from '../api/functionsApi';
 import { FunctionDetailSummary } from '../components/FunctionDetailSummary';
-import { Modal, Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+
 
 export class FunctionDetailPage extends Component {
   constructor(props) {
@@ -13,6 +14,8 @@ export class FunctionDetailPage extends Component {
     const { user, functionName } = props.match.params;
     this.handleShowBadgeModal = this.handleShowBadgeModal.bind(this);
     this.handleCloseBadgeModal = this.handleCloseBadgeModal.bind(this);
+    this.hoverOn = this.hoverOn.bind(this);
+    this.hoverOff = this.hoverOff.bind(this);
     this.state = {
       isLoading: true,
       fn: null,
@@ -20,6 +23,7 @@ export class FunctionDetailPage extends Component {
       repoPath,
       functionName,
       showBadgeModal: false,
+      copiedIcon: false,
     };    
   }
   componentDidMount() {
@@ -30,11 +34,16 @@ export class FunctionDetailPage extends Component {
     });
   }
   handleCloseBadgeModal() {
-    this.setState({ showBadgeModal: false });
+    this.setState({ showBadgeModal: false, copiedIcon: false });
   }
-
   handleShowBadgeModal() {
     this.setState({ showBadgeModal: true });
+  }
+  hoverOn() {
+    document.body.style.cursor = "pointer";
+  }
+  hoverOff() { 
+    document.body.style.cursor = "default"; 
   }
   render() {
     const { isLoading, fn } = this.state;
@@ -75,17 +84,21 @@ export class FunctionDetailPage extends Component {
                   <img src={badgeImage} alt="Powered by OpenFaaS &reg; Cloud" />
                 </a>
               </p>
-              <form>
-                <FormGroup
-                  controlId="formGetBadge">
-                  <FormControl
-                    readOnly
-                    type="text"
-                    value={badgeMd} />
-                  <FormControl.Feedback />
-                </FormGroup>
-              </form>
-            </Modal.Body>
+              <Form>                
+                <CopyToClipboard text={badgeMd}
+                  onCopy={() => this.setState({copiedIcon: true})}>                  
+                  <Well 
+                    bsSize="small" 
+                    onMouseEnter={this.hoverOn} 
+                    onMouseLeave={this.hoverOff}
+                    style={{ marginBottom: "10px" }}
+                  >
+                    {badgeMd}
+                  </Well>                  
+                </CopyToClipboard>
+                {this.state.copiedIcon ? <span style={{color: 'green'}}>Copied!</span> : null}
+              </Form>              
+            </Modal.Body>            
           </Modal>
       </div>
     );

--- a/dashboard/client/yarn.lock
+++ b/dashboard/client/yarn.lock
@@ -1750,6 +1750,12 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -5747,6 +5753,13 @@ react-bootstrap@^0.32.4:
     uncontrollable "^5.0.0"
     warning "^3.0.0"
 
+react-copy-to-clipboard@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-dev-utils@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.2.tgz#7bb68d2c4f6ffe7ed1184c5b0124fcad692774d2"
@@ -6876,6 +6889,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 toposort@^1.0.0:
   version "1.0.7"


### PR DESCRIPTION
Signed-off-by: Jaigouk Kim <ping@jaigouk.kim>

## Description

- added react-copy-to-clipboard
- clicking well area in modal will copy the markdown
- change text input to "well" : github shows token in similar way. no text input.
- fixes 1 left over issue in #172 (copy button)

## How Has This Been Tested?

manually

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
