### PR TITLE
Add handling of zero-length function names to router

### DIFF
--- a/router/main.go
+++ b/router/main.go
@@ -63,8 +63,11 @@ func makeHandler(c *http.Client, timeout time.Duration, upstreamURL string) func
 		host = r.Host[0:strings.Index(r.Host, tldSep)]
 
 		requestURI := r.RequestURI
-		if strings.HasPrefix(requestURI, "/") {
-			requestURI = requestURI[1:]
+		requestURI = strings.TrimLeft(requestURI, "/")
+
+		if len(requestURI) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
 		}
 
 		upstreamFullURL := fmt.Sprintf("%sfunction/%s-%s", upstreamURL, host, requestURI)

--- a/router/main_test.go
+++ b/router/main_test.go
@@ -50,6 +50,18 @@ func Test_makeHandler(t *testing.T) {
 			UpstreamURL:        "",
 			ExpectedStatusCode: http.StatusBadRequest,
 		},
+		{
+			Scenario:           "multiple function slash prefixes",
+			RequestURL:         "http://system.example.xyz/////dashboard",
+			UpstreamURL:        "/function/system-dashboard",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Scenario:           "missing function name",
+			RequestURL:         "http://system.example.xyz/",
+			UpstreamURL:        "",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
 	}
 
 	router := httptest.NewServer(passHandler{


### PR DESCRIPTION
## Description

If a OFC user strips the url to the base FQDN then an error message is returned that suggests the system has tried to route through to a function named 'user-'.  This change handles this scenario within the router so that a 404 is returned.

Additional small change was made to the way leading slashes in the requestURI are handled in the router, removing the assumption that only a single slash would occur.

Signed-off-by: Richard Gee <richard@technologee.co.uk>

## How Has This Been Tested?
* Added pre-change test scenarios to `Test_makeHandler(t *testing.T)` to exercise the issue:

```
        {
            Scenario: "multiple function slash prefixes",
            RequestURL: "http://system.example.xyz/////dashboard",
            UpstreamURL: "/function/system-dashboard",
            ExpectedStatusCode: http.StatusOK,
        },
        {
            Scenario: "missing function name",
            RequestURL: "http://system.example.xyz/",
            UpstreamURL: "",
            ExpectedStatusCode: http.StatusNotFound,
        },
```

* Confirmed tests as failing:

```
Running tool: /usr/local/go/bin/go test -coverprofile=/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/go-code-cover -timeout 30s

Upstream http://127.0.0.1:52925/function/system-dashboard status: 200
Upstream http://127.0.0.1:52925/function/system-////dashboard status: 200
Upstream http://127.0.0.1:52925/function/system- status: 200
--- FAIL: Test_makeHandler (0.00s)
--- FAIL: Test_makeHandler/multiple_function_slash_prefixes (0.00s)
    /Users/rgee0/go/src/github.com/openfaas/openfaas-cloud/router/main_test.go:95: RequestURI want: /function/system-dashboard, got: /function/system-////dashboard
--- FAIL: Test_makeHandler/missing_function_name (0.00s)
    /Users/rgee0/go/src/github.com/openfaas/openfaas-cloud/router/main_test.go:89: Status code want: 404, got 200
    /Users/rgee0/go/src/github.com/openfaas/openfaas-cloud/router/main_test.go:95: RequestURI want: , got: /function/system-
FAIL
coverage: 68.7% of statements
exit status 1
FAIL    github.com/openfaas/openfaas-cloud/router   0.021s
Error: Tests failed.
```

* Made the changes and confirmed tests pass and increased coverage:

```
Running tool: /usr/local/go/bin/go test -coverprofile=/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/go-code-cover -timeout 30s

Upstream http://127.0.0.1:52973/function/system-dashboard status: 200
Upstream http://127.0.0.1:52973/function/system-dashboard status: 200
PASS
coverage: 69.6% of statements
ok  	github.com/rgee0/openfaas-cloud/router	0.021s
Success: Tests passed.
```

* Built and pushed the image `rgee0/of-router:missingFunction`.

* Built a new instance and confirmed issue exists:
```
$ docker service ls | grep of-router
69dgm98beqyl        of-router             replicated          1/1                 openfaas/cloud-router:0.3.0       *:80->8080/tcp

$  curl -v cloud.technologee.co.uk
* Rebuilt URL to: cloud.technologee.co.uk/
*   Trying 178.128.175.206...
* TCP_NODELAY set
* Connected to cloud.technologee.co.uk (178.128.175.206) port 80 (#0)
> GET / HTTP/1.1
> Host: cloud.technologee.co.uk
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Content-Length: 93
< Content-Type: text/plain; charset=utf-8
< Date: Sun, 23 Sep 2018 11:47:02 GMT
< 
* Connection #0 to host cloud.technologee.co.uk left intact
error finding function cloud-: server returned non-200 status code (404) for function, cloud-
```

* Updated the router image and re-ran:

```
$ docker service ls | grep of-router
69dgm98beqyl        of-router             replicated          1/1                 rgee0/of-router:missingFunction   *:80->8080/tcp

$ curl -v cloud.technologee.co.uk
* Rebuilt URL to: cloud.technologee.co.uk/
*   Trying 178.128.175.206...
* TCP_NODELAY set
* Connected to cloud.technologee.co.uk (178.128.175.206) port 80 (#0)
> GET / HTTP/1.1
> Host: cloud.technologee.co.uk
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Date: Sun, 23 Sep 2018 11:49:30 GMT
< Content-Length: 0
< Content-Type: text/plain; charset=utf-8
< 
* Connection #0 to host cloud.technologee.co.uk left intact

```
This confirmed the router is now returning the 404 rather than passing through to the gateway.

## How are existing users impacted? What migration steps/scripts do we need?
This is a bug fix to address situations where the user might strip back the URL to remove the function name.  Users should not be impacted unless they are relying on this unintended behaviour.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
