### PR TITLE
Added dynamic metrics_window param to system-metrics

### DIFF
--- a/system-metrics/README.md
+++ b/system-metrics/README.md
@@ -11,8 +11,8 @@ It queries Prometheus for a function's 2xx and non-2xx invocations count and ret
 }
 ```
 
-It takes function's name (i.e. `myFunction`) from a query and is invoked by GET request to
-http://gateway-url:8080/function/system-metrics?function=myFunction
+It takes function's name (i.e. `myFunction` \[required\]) and metrics_window (i.e. `24h` \[default: 60m\] from a query and is invoked by GET request to
+http://gateway-url:8080/function/system-metrics?function=myFunction&metrics_window=24h
 
 > Note: If you're running the function on Swarm, you should update `prometheus_host` in `gateway_config.yml` to `prometheus`, i.e. removing the namespace suffix for Kubernetes.
 

--- a/system-metrics/hadler_test.go
+++ b/system-metrics/hadler_test.go
@@ -2,6 +2,8 @@ package function
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/openfaas/faas/gateway/metrics"
@@ -84,5 +86,31 @@ func Test_getMetrics(t *testing.T) {
 		expectedJSON, _ := json.Marshal(expected)
 
 		t.Errorf("Expected %s, but got %v", expectedJSON, gotJSON)
+	}
+}
+
+func Test_parseMetricsWindow_whenMetricsWindowIsNotSetInQuery(t *testing.T) {
+	expected := "60m"
+
+	got := parseMetricsWindow()
+
+	if expected != got {
+		t.Errorf("Expected: %s, got: %s", expected, got)
+	}
+}
+
+func Test_parseMetricsWindow_whenMetricsWindowIsSetInQuery(t *testing.T) {
+	expected := "61h"
+
+	err := os.Setenv("Http_Query", fmt.Sprintf("metrics_window=%s", expected))
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	got := parseMetricsWindow()
+
+	if expected != got {
+		t.Errorf("Expected: %s, got: %s", expected, got)
 	}
 }

--- a/system-metrics/handler.go
+++ b/system-metrics/handler.go
@@ -33,11 +33,7 @@ func Handle(req []byte) string {
 	}
 
 	metricsQuery := metrics.NewPrometheusQuery(host, port, &http.Client{})
-	metricsWindow := os.Getenv("metrics_window")
-
-	if metricsWindow == "" {
-		metricsWindow = "60m"
-	}
+	metricsWindow := parseMetricsWindow()
 
 	fnMetrics, err := getMetrics(fnName, metricsQuery, metricsWindow)
 	if err != nil {
@@ -49,6 +45,26 @@ func Handle(req []byte) string {
 		log.Fatalf("Couldn't marshal json %t", err)
 	}
 	return string(res)
+}
+
+func parseMetricsWindow() string {
+	if query, exists := os.LookupEnv("Http_Query"); exists {
+		vals, _ := url.ParseQuery(query)
+
+		metricsWindow := vals.Get("metrics_window")
+
+		if len(metricsWindow) > 0 {
+			return metricsWindow
+		}
+	}
+
+	metricsWindow := os.Getenv("metrics_window")
+
+	if metricsWindow == "" {
+		metricsWindow = "60m"
+	}
+
+	return metricsWindow
 }
 
 func parseFunctionName() (functionName string, error error) {


### PR DESCRIPTION
Closes https://github.com/openfaas/openfaas-cloud/issues/231

Currently you can't change metrics_window and this commit changes
that, adding option of passing metrics_window paramter in query string
for system-metrics, which will change the window. For example:
http://127.0.0.1:8080/function/system-metrics?function=nodeinfo&metrics_window=24h

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Query: `https://gateway.dedal.io/function/system-metrics?function=bartsmykla-go-fn&metrics_window=48h`:
```json
{"success":1124,"failure":3}
```
Query: `https://gateway.dedal.io/function/system-metrics?function=bartsmykla-go-fn&metrics_window=24h`
```json
{"success":2,"failure":0}
```
Query: `https://gateway.dedal.io/function/system-metrics?function=bartsmykla-go-fn`
```json:
{"success":0,"failure":0}
```
Query: `https://gateway.dedal.io/function/system-metrics?function=bartsmykla-go-fn&metrics_window=60m`
```json:
{"success":0,"failure":0}
```

## How are existing users impacted? What migration steps/scripts do we need?
They are not impacted


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
