### PR TITLE
WIP: Added private repo label for private functions

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -154,13 +154,14 @@ func Handle(req []byte) string {
 			Image:   imageName,
 			Network: "func_functions",
 			Labels: map[string]string{
-				sdk.FunctionLabelPrefix + "git-cloud":      "1",
-				sdk.FunctionLabelPrefix + "git-owner":      event.Owner,
-				sdk.FunctionLabelPrefix + "git-repo":       event.Repository,
-				sdk.FunctionLabelPrefix + "git-deploytime": strconv.FormatInt(time.Now().Unix(), 10), //Unix Epoch string
-				sdk.FunctionLabelPrefix + "git-sha":        event.SHA,
-				"faas_function":                            serviceValue,
-				"app":                                      serviceValue,
+				sdk.FunctionLabelPrefix + "git-cloud":        "1",
+				sdk.FunctionLabelPrefix + "git-owner":        event.Owner,
+				sdk.FunctionLabelPrefix + "git-repo":         event.Repository,
+				sdk.FunctionLabelPrefix + "git-deploytime":   strconv.FormatInt(time.Now().Unix(), 10), //Unix Epoch string
+				sdk.FunctionLabelPrefix + "git-sha":          event.SHA,
+				sdk.FunctionLabelPrefix + "git-private-repo": strconv.FormatBool(event.Private),
+				"faas_function":                              serviceValue,
+				"app":                                        serviceValue,
 				"com.openfaas.scale.min": scalingMinLimit,
 				"com.openfaas.scale.max": scalingMaxLimit,
 			},


### PR DESCRIPTION
If function was build from private github repository it will receive
label com.openfaas.cloud.git-private-repo=true

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description


## How Has This Been Tested?
WIP
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?



## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
