### PR TITLE
Make minor accuracy changes to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -151,10 +151,6 @@ By default all settings are prepared for Kubernetes, so if you're using Swarm do
 
 In `gateway_config.yml` and `./dashboard/stack.yml` remove the suffix `.openfaas` where you see it.
 
-#### Set limits
-
-You will need to edit `stack.yml` and make sure `buildshiprun_limits_swarm.yml` is listed instead of `buildshiprun_limits_k8s.yml`.
-
 ### Deploy your container builder
 
 You need to generate the ```~/.docker/config.json``` using the ```docker login``` command. 
@@ -191,7 +187,7 @@ Log into your registry or the Docker hub
 ```
 docker login
 ```
-Expect to see ```WARNING! Your password will be stored unencrypted in /Users/kvuchkov/.docker/config.json``` in the output.
+Expect to see ```WARNING! Your password will be stored unencrypted in ~/.docker/config.json``` in the output.
 
 This populates `~/.docker/config.json` which is used in the builder:
 ```json
@@ -253,7 +249,7 @@ Create of-builder and of-buildkit:
 
 ### Configure push repository and gateway URL
 
-In gateway.yml
+In gateway_config.yml
 
 ```yaml
 environment:


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Small changes to the docs README:
* Remove #set limits, which now has a generic filename so doesn't need switching between k8s/swarm.
* Remove reference to a specific user's home directory and replace with ~
* Update `gateway.yml` to `gateway_config.yml`

## How Has This Been Tested?
Followed the flow using k8s on a clean instance and corrected where issues were encountered.

## How are existing users impacted? What migration steps/scripts do we need?
No migration necessary.  Users should find the instructions closer to reality.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
