### PR TITLE
Add faas version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -26,6 +26,8 @@
 
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
+* FaaS-CLI version ( Full output from: `faas-cli version` ):
+
 * Docker version `docker version` (e.g. Docker 17.0.05 ):
 
 * Are you using Docker Swarm or Kubernetes (FaaS-netes)?


### PR DESCRIPTION
This commit adds a line to the issue template
to request the faas-cli version and provider
information to the issue template to help diagnose
issues faster

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
No impact to existing users, only a change to the Github issue template for newly created issues


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
