### PR TITLE
Handle private repo in git-tar and buildshiprun

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -296,7 +296,11 @@ func getEvent() (*sdk.Event, error) {
 	info.SHA = os.Getenv("Http_Sha")
 	info.URL = os.Getenv("Http_Url")
 	info.Image = os.Getenv("Http_Image")
+<<<<<<< HEAD
 	info.SCM = os.Getenv("Http_Scm")
+=======
+	info.Private, _ = strconv.ParseBool(os.Getenv("Http_Private"))
+>>>>>>> Handle private repo in git-tar and buildshiprun
 
 	if len(os.Getenv("Http_Installation_id")) > 0 {
 		info.InstallationID, err = strconv.Atoi(os.Getenv("Http_Installation_id"))

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -312,7 +312,11 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services, sta
 	url := pushEvent.Repository.CloneURL
 	afterCommitID := pushEvent.AfterCommitID
 	installationID := pushEvent.Installation.ID
+<<<<<<< HEAD
 	sourceManagement := pushEvent.SCM
+=======
+	privateRepo := pushEvent.Repository.Private
+>>>>>>> Handle private repo in git-tar and buildshiprun
 
 	c := http.Client{}
 	gatewayURL := os.Getenv("gateway_url")
@@ -369,7 +373,11 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services, sta
 		httpReq.Header.Add("Service", tarEntry.functionName)
 		httpReq.Header.Add("Image", tarEntry.imageName)
 		httpReq.Header.Add("Sha", afterCommitID)
+<<<<<<< HEAD
 		httpReq.Header.Add("Scm", sourceManagement)
+=======
+		httpReq.Header.Add("Private", strconv.FormatBool(privateRepo))
+>>>>>>> Handle private repo in git-tar and buildshiprun
 
 		envJSON, marshalErr := json.Marshal(stack.Functions[tarEntry.functionName].Environment)
 		if marshalErr != nil {


### PR DESCRIPTION
Making git-tar send the private-repo field handled by
pushEvent to buildshiprun for the function to be builded
with private-repo and list-functions to contain the field

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

This extends or prequels the PR #235 to give the field containing whether or not the repository is private or not to `buildshiprun`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Build/Push `git-tar` and `buildshiprun` with the change and Deploy the function on my cloud instance and output of list-functions is 
```
[{"name":"martindekov-gocloudfunc","image":"martindekov-gocloudfunc-gocloudfunc:latest-1cc6058","invocationCount":5,"replicas":1,"labels":{"app":"martindekov-gocloudfunc","com.openfaas.cloud.git-cloud":"1","com.openfaas.cloud.git-deploytime":"1538039310","com.openfaas.cloud.git-owner":"martindekov","com.openfaas.cloud.git-private-repo":"false","com.openfaas.cloud.git-repo":"gocloudfunc","com.openfaas.cloud.git-sha":"1cc6058cecb7522ec49d51f60142cf53730e5aaa","com.openfaas.function":"martindekov-gocloudfunc","com.openfaas.scale.max":"4","com.openfaas.scale.min":"1","faas_function":"martindekov-gocloudfunc","function":"true"}}]
```
And output of git-tar is
```
...
git-tar.1.z1jcz0lyekp6@FaasSwarm    |  [{martindekov-gocloudfunc martindekov-gocloudfunc-gocloudfunc:latest-1cc6058 map[com.openfaas.cloud.git-owner:martindekov com.openfaas.cloud.git-private-repo:false com.openfaas.cloud.git-repo:gocloudfunc com.openfaas.scale.max:4 faas_function:martindekov-gocloudfunc app:martindekov-gocloudfunc com.openfaas.cloud.git-cloud:1 com.openfaas.cloud.git-deploytime:1538039310 function:true com.openfaas.cloud.git-sha:1cc6058cecb7522ec49d51f60142cf53730e5aaa com.openfaas.function:martindekov-gocloudfunc com.openfaas.scale.min:1]}]Garbage collection ran for martindekov/gocloudfunc - 0 functions deleted.
...
```
Closes #218 

## How are existing users impacted? What migration steps/scripts do we need?

N.A. it just adds another field when building the functions

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
