### PR TITLE
Call garbage-collect through async route

### DIFF
--- a/github-event/handler.go
+++ b/github-event/handler.go
@@ -156,7 +156,7 @@ func garbageCollect(garbageRequests []GarbageRequest) error {
 
 		body, _ := json.Marshal(garbageRequest)
 		bodyReader := bytes.NewReader(body)
-		req, _ := http.NewRequest(http.MethodPost, gatewayURL+"function/garbage-collect", bodyReader)
+		req, _ := http.NewRequest(http.MethodPost, gatewayURL+"async-function/garbage-collect", bodyReader)
 
 		digest := hmac.Sign(body, []byte(payloadSecret))
 		req.Header.Add(sdk.CloudSignatureHeader, "sha1="+hex.EncodeToString(digest))
@@ -168,7 +168,8 @@ func garbageCollect(garbageRequests []GarbageRequest) error {
 		if res.Body != nil {
 			defer res.Body.Close()
 		}
-		if res.StatusCode != http.StatusOK {
+		if res.StatusCode != http.StatusAccepted {
+			log.Printf("Unexpected status code for function: `%s` - %d\n", garbageRequest.Repo, res.StatusCode)
 			resBody, _ := ioutil.ReadAll(res.Body)
 			fmt.Printf("Error in garbageCollect: %s\n", resBody)
 		}


### PR DESCRIPTION
Calling garbage-collect through async route in github-event
so the request wont time out in case we have couple of functions
deployed

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

This is small tweak that enables calling garbage-collect through async route for the times user with couple of functions want to uninstall the application and delete all its functions from the cloud.

Closes #221 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All function deleted with logs logs 
```
...
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Need to remove: martindekov/bottester.
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Need to remove: martindekov/goforfun.
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Need to remove: martindekov/gocloudfunc.
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Need to remove: martindekov/cloudlogo.
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Need to remove: martindekov/kubernetesgo.
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Status code for garbageCollect: 202
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Status code for garbageCollect: 202
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Status code for garbageCollect: 202
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Status code for garbageCollect: 202
system-github-event.1.w4bvfwjy9l3l@FaasSwarm    | Status code for garbageCollect: 202
...
```

## How are existing users impacted? What migration steps/scripts do we need?

No migration needed, just added feature.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
