### PR TITLE
Add truncate method to github-status

### DIFF
--- a/github-status/handler.go
+++ b/github-status/handler.go
@@ -328,3 +328,12 @@ func hmacEnabled() bool {
 func buildStatus(status string, desc string, context string, url string) *github.RepoStatus {
 	return &github.RepoStatus{State: &status, TargetURL: &url, Description: &desc, Context: &context}
 }
+
+func truncate(maxLength int, message string) (string, bool) {
+	truncated := false
+	if len(message) > maxLength {
+		message = message[len(message)-maxLength:]
+		truncated = true
+	}
+	return message, truncated
+}

--- a/github-status/handler_test.go
+++ b/github-status/handler_test.go
@@ -402,3 +402,46 @@ func TestFormatLogs(t *testing.T) {
 		t.Fatalf("Empty logs shoud produce null formatted text")
 	}
 }
+
+func Test_truncated(t *testing.T) {
+	tests := []struct {
+		title           string
+		length          int
+		message         string
+		expectedMessage string
+		expectedBool    bool
+	}{
+		{
+			title:           "Exceeding 5 characters",
+			length:          7,
+			message:         "Some random string",
+			expectedMessage: " string",
+			expectedBool:    true,
+		},
+		{
+			title:           "Not exceeding 5 characters",
+			length:          5,
+			message:         "Some",
+			expectedMessage: "Some",
+			expectedBool:    false,
+		},
+		{
+			title:           "Right at 5 characters",
+			length:          5,
+			message:         "Some ",
+			expectedMessage: "Some ",
+			expectedBool:    false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			message, truncated := truncate(test.length, test.message)
+			if truncated != test.expectedBool {
+				t.Errorf("Expected truncated to be: `%v`, got: `%v`", test.expectedBool, truncated)
+			}
+			if message != test.expectedMessage {
+				t.Errorf("Expected message to be: `%v`, got: `%v`", test.expectedBool, truncated)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding truncate method in github status

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Truncate method to trim strings if they exceed given length e.g. "some string" max chars 5 will give "tring"

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created test for it

## How are existing users impacted? What migration steps/scripts do we need?

N.A.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
