### PR TITLE
Add auditing for garbage-collect

### DIFF
--- a/garbage-collect/Gopkg.lock
+++ b/garbage-collect/Gopkg.lock
@@ -3,25 +3,34 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:ccd02c1417d1cbe8deecfab8d885ee1d84a02a48bb6a226dc9c1d3b4b66ce347"
   name = "github.com/alexellis/hmac"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5c52ab81c0de69124b2bac9eab16c326e22dfada"
 
 [[projects]]
+  digest = "1:bdc1992e06609e1a3204271c66f4a09ca742346cec96605c969aab22082d7cbe"
   name = "github.com/openfaas/faas"
   packages = ["gateway/types"]
+  pruneopts = "UT"
   revision = "e67811c91c006dfe86feb945c88b0738ddf33a67"
   version = "0.9.4"
 
 [[projects]]
+  digest = "1:6c40fef89b608d7c3ae933e17c4406bc170cd5e1e3600e60a8a1e4be4c754843"
   name = "github.com/openfaas/openfaas-cloud"
   packages = ["sdk"]
+  pruneopts = "UT"
   revision = "965a437d05c2818dacfbfb45c56ea3f9f20f447a"
   version = "0.5.8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0a0c4edebf09601366dca58b98fdf82c7ac43d821d6d527e5ad646d3c57d8aa7"
+  input-imports = [
+    "github.com/alexellis/hmac",
+    "github.com/openfaas/openfaas-cloud/sdk",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.lock
+++ b/garbage-collect/vendor/github.com/openfaas/openfaas-cloud/sdk/Gopkg.lock
@@ -2,20 +2,27 @@
 
 
 [[projects]]
+  digest = "1:871b7cfa5fe18bfdbd4bf117c166c3cff8d3b61c8afe4e998b5b8ac0c160ca24"
   name = "github.com/alexellis/hmac"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d5d71edd7bc74eb6ae4b99eccc6bda738435f43f"
   version = "1.2"
 
 [[projects]]
+  digest = "1:cb12bf73c4bbdf76b5ea487a551a6fc6f1c61dd7629c96d6f956f32f24832701"
   name = "github.com/openfaas/faas"
   packages = ["gateway/types"]
+  pruneopts = "UT"
   revision = "c86de503c7a20a46645239b9b081e029b15bf69b"
   version = "0.8.11"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cbb5ffd7a070a945aad1f1889e544b41bb16bbe883df7f3b14ffe5d98e19c6c3"
+  input-imports = [
+    "github.com/alexellis/hmac",
+    "github.com/openfaas/faas/gateway/types",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Sending events to through auditEvent in the cases when:
 - deletion of funtions starts
 - function is not deleted/unable to delete
 - deletion of functions is finished

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Added auditing for the `garbage-collect` function in three places:
 - deletion of funtions starts
 - function is not deleted/unable to delete
 - deletion of functions is finished

Closes #248 

Note: Did not add audit for all errors since the issue suggests that we need auditing around the removal process. I can add auditing on every error if requested.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A. Does not alter the main `garbage-collect` functionality.

## How are existing users impacted? What migration steps/scripts do we need?

N.A. This just audits the event it does not intercept the functionality

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
