### PR TITLE
Add support for custom templates

### DIFF
--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -6,6 +6,8 @@ environment:
   audit_url: http://gateway.openfaas:8080/function/audit-event
   # Remove gateway_pretty_url if not using pretty URL
   gateway_pretty_url: https://user.o6s.io/function
+  # Comment out for custom templates and separate URLs using unicode.IsSpace
+  # custom_templates: "https://github.com/custom/template.git, https://github.com/custom/template2.git"
 
 # Security
   customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -44,9 +44,7 @@ func parseYAML(pushEvent sdk.PushEvent, filePath string) (*stack.Services, error
 }
 
 func fetchTemplates(filePath string) error {
-	templateRepos := []string{"https://github.com/openfaas/templates",
-		"https://github.com/openfaas-incubator/node8-express-template.git",
-		"https://github.com/openfaas-incubator/golang-http-template.git"}
+	templateRepos := formatTemplateRepos()
 
 	for _, repo := range templateRepos {
 		pullCmd := exec.Command("faas-cli", "template", "pull", repo)
@@ -488,4 +486,27 @@ func importSecrets(pushEvent sdk.PushEvent, stack *stack.Services, clonePath str
 	fmt.Println("Parsed sealed secrets", res.Status, owner)
 
 	return nil
+}
+
+// getShortSHA returns shorter version of git commit SHA
+func getShortSHA(sha string) string {
+	if len(sha) <= 7 {
+		return sha
+	}
+	return sha[:7]
+}
+
+func formatTemplateRepos() []string {
+	templateRepos := []string{"https://github.com/openfaas/templates",
+		"https://github.com/openfaas-incubator/node8-express-template.git",
+		"https://github.com/openfaas-incubator/golang-http-template.git"}
+
+	if envTemplates := os.Getenv("custom_templates"); len(envTemplates) > 0 && strings.Contains(envTemplates, "https://") {
+		customTemplates := strings.Split(envTemplates, ",")
+		for _, repo := range customTemplates {
+			repo = strings.Trim(repo, " ")
+			templateRepos = append(templateRepos, repo)
+		}
+	}
+	return templateRepos
 }

--- a/git-tar/function/ops_test.go
+++ b/git-tar/function/ops_test.go
@@ -2,6 +2,8 @@ package function
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	// internal dependencies
@@ -98,5 +100,108 @@ func Test_getRepositoryURL_whenGetTokenReturnsError_WhenRepositoryIsPrivate(t *t
 
 	if gotURL != expectedURL {
 		t.Errorf("Expected URL: %s, Got: %s", expectedURL, gotURL)
+	}
+}
+
+func Test_formatTemplateReposValid(t *testing.T) {
+	formalRepos := []string{
+		"https://github.com/openfaas/templates",
+		"https://github.com/openfaas-incubator/node8-express-template.git",
+		"https://github.com/openfaas-incubator/golang-http-template.git",
+	}
+
+	tests := []struct {
+		title         string
+		envRepos      string
+		expectedRepos []string
+	}{
+		{
+			title:         "Templates with no added custom repositories",
+			envRepos:      "",
+			expectedRepos: formalRepos,
+		},
+		{
+			title:         "Templates with single added custom repository",
+			envRepos:      "https://github.com/my-custom/repo.git",
+			expectedRepos: append(formalRepos, "https://github.com/my-custom/repo.git"),
+		},
+		{
+			title:         "Templates with two added custom repositories without spaces",
+			envRepos:      "https://github.com/my-custom/repo.git,https://github.com/another/repo.git",
+			expectedRepos: append(formalRepos, ([]string{"https://github.com/my-custom/repo.git", "https://github.com/another/repo.git"})...),
+		},
+	}
+	for _, test := range tests {
+		os.Setenv("custom_templates", test.envRepos)
+		t.Run(test.title, func(t *testing.T) {
+			templateRepos := formatTemplateRepos()
+			for _, templateRepo := range templateRepos {
+				for final, expectedRepo := range test.expectedRepos {
+					if expectedRepo == templateRepo {
+						continue
+					}
+					if final == len(test.expectedRepos) {
+						t.Errorf("Expecting repositories: \n`%s` \ngot: \n`%s`",
+							strings.Join(test.expectedRepos, " "),
+							strings.Join(templateRepos, " "))
+					}
+
+				}
+			}
+		})
+	}
+}
+
+func Test_formatTemplateReposUnvalid(t *testing.T) {
+	formalRepos := []string{
+		"https://github.com/openfaas/templates",
+		"https://github.com/openfaas-incubator/node8-express-template.git",
+		"https://github.com/openfaas-incubator/golang-http-template.git",
+	}
+
+	tests := []struct {
+		title         string
+		envRepos      string
+		expectedRepos []string
+	}{
+		{
+			title:         "Variable set invalid",
+			envRepos:      " ",
+			expectedRepos: formalRepos,
+		},
+		{
+			title:         "Variable set with random symbols",
+			envRepos:      "123randomzxc",
+			expectedRepos: formalRepos,
+		},
+		{
+			title:         "Invalid github URLs (Missing `https://`)",
+			envRepos:      "www.github.com/my-custom/repo.git",
+			expectedRepos: formalRepos,
+		},
+		{
+			title:         "Setting values with spaces between commas",
+			envRepos:      " , https://github.com/my-custom/repo.git, https://github.com/another/repo.git, ",
+			expectedRepos: append(formalRepos, ([]string{"https://github.com/my-custom/repo.git", "https://github.com/another/repo.git"})...),
+		},
+	}
+	for _, test := range tests {
+		os.Setenv("custom_templates", test.envRepos)
+		t.Run(test.title, func(t *testing.T) {
+			templateRepos := formatTemplateRepos()
+			for _, templateRepo := range templateRepos {
+				for final, expectedRepo := range test.expectedRepos {
+					if expectedRepo == templateRepo {
+						continue
+					}
+					if final == len(test.expectedRepos) {
+						t.Errorf("Expecting repositories: \n`%s` \ngot: \n`%s`",
+							strings.Join(test.expectedRepos, " "),
+							strings.Join(templateRepos, " "))
+					}
+
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Enable users which have their own instance of OF-cloud
to add their own template repositories through configuration
rather than manually enter in the code and applying changes
to the right place

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

This Closes #229. I went with the approach that separates the repositories with comma
```
custom_templates: "https://github.com/single/template.git, https://github.com/another/template.git"
```
though if requested can find a way to change this maybe with 
```
custom_templates:
  - https://github.com/single/template.git
  - https://github.com/another/template.git
```
But I can't think of a way to get those values from single key without having to parse yaml, which means I must copy the file inside the container and then parse ..

Went with separate function since the `fetchTemplates(something)` with that change would now format the templates AND fetch them and the function becomes too long for the thing it does(fetching) also inconvenient for testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests also tested on my cloud with image `martindekov/of-git-tar:261` and modified configuration in `gateway_config.yml` with `custom_templates` variable like so 
```
...
  custom_templates: "https://github.com/openfaas-incubator/python-flask-template.git, https://github.com/openfaas-incubator/ruby-http.git"
...
```
the content of the folder inside the container is
```
$ ls template
csharp                   golang-http              java8                    node8-express            python-armhf             python3-flask
dockerfile               golang-http-armhf        node                     node8-express-armhf      python27-flask           python3-flask-armhf
go                       golang-middleware        node-arm64               php7                     python3                  ruby
go-armhf                 golang-middleware-armhf  node-armhf               python                   python3-armhf            ruby-http
```
Commented out the custom_templates like in `gateway_config.yml` like so
```
...
  #custom_templates: "https://github.com/openfaas-incubator/python-flask-template.git, https://github.com/openfaas-incubator/ruby-http.git"
...
```
and inside the container the templates folder contains
```
$ ls template
csharp                   golang-http              java8                    node8-express            python-armhf
dockerfile               golang-http-armhf        node                     node8-express-armhf      python3
go                       golang-middleware        node-arm64               php7                     python3-armhf
go-armhf                 golang-middleware-armhf  node-armhf               python                   ruby
```
## How are existing users impacted? What migration steps/scripts do we need?

N.A. This change is enhancement.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
