### PR TITLE
Add whole repository URL handling to SDK

### DIFF
--- a/sdk/events.go
+++ b/sdk/events.go
@@ -19,6 +19,7 @@ type PushEvent struct {
 	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
 	Installation  PushEventInstallation
+	RepositoryURL string `json:"url"`
 }
 
 // Owner is the owner of a GitHub repo


### PR DESCRIPTION
Adding handling for the whole PushEvent to SDK which can be used
to add SCM and fix dashboard pointing to wrong adress

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

This is the first of two PRs which references issue #210 adds handling for whole repository on pushEvent to fix dashboard breaking for non-github SCMs also referencing #224 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

If they update their versions of the functions then they would need to update their dashboards also.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
