### PR TITLE
Add Customer struct

### DIFF
--- a/sdk/events.go
+++ b/sdk/events.go
@@ -41,6 +41,14 @@ type Event struct {
 	Private        bool              `json:"private"`
 }
 
+type Customer struct {
+	Sender Sender `json:"sender"`
+}
+
+type Sender struct {
+	Login string `json:"login"`
+}
+
 // BuildEventFromPushEvent function to build Event from PushEvent
 func BuildEventFromPushEvent(pushEvent PushEvent) *Event {
 	info := Event{}


### PR DESCRIPTION
Adding Customer struct which contains Login field to handle
the general case when user sends events to the cloud

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Adding `Customer` struct for the owner of the event to be recognized in event rather than `github-push`

This is 1/2 Part of two part PR that referenced #163 . 

The struct is separate since it is present in every event we support.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

N.A. This is struct update

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
