### PR TITLE
Extend claims with organization field

### DIFF
--- a/auth/handlers/common.go
+++ b/auth/handlers/common.go
@@ -17,6 +17,9 @@ type OpenFaaSCloudClaims struct {
 	// AccessToken for use with the GitHub Profile API
 	AccessToken string `json:"access_token"`
 
+	// String with all organizations separated with commas
+	Organizations string `json:"organizations"`
+
 	// Inherit from standard claims
 	jwt.StandardClaims
 }

--- a/auth/handlers/common_test.go
+++ b/auth/handlers/common_test.go
@@ -18,8 +18,8 @@ func TestCombineURL_BuildsValidURL(t *testing.T) {
 
 func Test_buildGitLabURL(t *testing.T) {
 	c := &Config{
-		OAuthProviderBaseURL: "https://foo.bar",
-		ClientID: "baz",
+		OAuthProviderBaseURL:   "https://foo.bar",
+		ClientID:               "baz",
 		ExternalRedirectDomain: "http://bazfoz.com",
 	}
 
@@ -63,5 +63,33 @@ func Test_buildGitLabURL(t *testing.T) {
 			expectedQuery.Get("redirect_uri"),
 			gotQuery.Get("redirect_uri"),
 		)
+	}
+}
+
+func Test_GetOrganizations(t *testing.T) {
+	tests := []struct {
+		Title                 string
+		ExistingOrganizations OpenFaaSCloudClaims
+		ExpectedOrganizations []string
+	}{
+		{
+			Title: "Example with properly separated organizations with comma",
+			ExistingOrganizations: OpenFaaSCloudClaims{Organizations: "openfaas,openfaas-incubator,openfaas-cloud"},
+			ExpectedOrganizations: []string{"openfaas", "openfaas-incubator", "openfaas-cloud"},
+		}, {
+			Title: "Example with un-proper separation of organizations with space",
+			ExistingOrganizations: OpenFaaSCloudClaims{Organizations: "openfaas openfaas-incubator openfaas-cloud"},
+			ExpectedOrganizations: []string{"openfaas openfaas-incubator openfaas-cloud"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Title, func(t *testing.T) {
+			organizations := test.ExistingOrganizations.GetOrganizations()
+			for order, value := range organizations {
+				if test.ExpectedOrganizations[order] != value {
+					t.Errorf("Expected: %s got: %s", test.ExpectedOrganizations[order], value)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Added funcion which calls the github api to get all the
organization the user is in and store them in struct
OpenFaaSCloudClaims

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Extended `OpenFaaSCloudClaims` to contain `Organizations` field which is populated by function which I added in the PR that takes all the organizations that user is in and adds them into comma separated string. References #234 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TO DO

## How are existing users impacted? What migration steps/scripts do we need?

Can access organization functions

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
