### PR TITLE
Auth: Support GitLab via OAuth 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,17 @@ OpenFaaS Cloud - portable, multi-user Serverless Functions powered by GitOps
 
 ## Description
 
-OpenFaaS Cloud is a portable, multi-user Serverless Functions platform powered by GitOps. OpenFaaS Cloud introduces a build-system for your functions and native integrations into GitHub meaning that you just run `git push` to deploy your code. As soon as OpenFaaS Cloud receives the `push event` it will clone your Git repo, build, push and then deploy your function with a rolling update to your own sub-domain with HTTPS.
+OpenFaaS Cloud is a portable, multi-user Serverless Functions platform powered by GitOps. OpenFaaS Cloud introduces a build-system for your functions and native integrations into GitHub/GitLab meaning that you just run `git push` to deploy your code. As soon as OpenFaaS Cloud receives the `push event` it will clone your Git repo, build, push and then deploy your function with a rolling update to your own sub-domain with HTTPS.
 
 Features:
 
 * Portable - run anywhere or use the hosted Community Cluster
-* Multi-user - use your GitHub identity to log into your personal dashboard
+* Multi-user - use your GitHub/GitLab identity to log into your personal dashboard
 * Applies GitOps principles - your `git` repo is the source of truth
-* Integrate repos with a single click  through the *GitHub App*
+* Integrate repos with a single click  through the *GitHub App* or *GitLab repo tags*.
 * Immediate feedback - live build notifications for your commits
 * HTTPS endpoints per user
-* Secured through HMAC - the public facing function "github-event" uses HMAC to verify the origin of events
+* Secured through HMAC - the public facing functions "github-event" and "gitlab-event" uses HMAC to verify the origin of events
 
 > OpenFaaS Cloud packages, builds and deploys functions using OpenFaaS. Moby's BuildKit is used to build images and push to a local Docker registry instance.
 
@@ -74,9 +74,9 @@ Read my [introducing OpenFaaS Cloud](https://blog.alexellis.io/introducing-openf
 * Stretch goals
 
 - [x] Move Dashboard UI to React.js
-- [ ] Re-write React.js Dashboard to use native Bootstrap library
+- [x] Re-write React.js Dashboard to use native Bootstrap library
 - [ ] CI/CD integration with on-prem GitLab (in-progress)
-- [ ] UI: OAuth 2 login via GitLab (planned, help wanted)
+- [x] UI: OAuth 2 login via GitLab
 - [ ] Unprivileged builds with BuildKit or similar (under investigation)
 - [ ] Log into OpenFaaS Cloud via CLI (faas-cli cloud login)
 - [ ] Enable untrusted container builds via docker-machine?
@@ -98,7 +98,7 @@ The buildkit GRPC daemon which builds the image and pushes it to the internal re
 
 * Microservice: of-router
 
-The router component is the only ingress point for HTTP requests for serving functions and for enabling the GitHub integration. It translates "pretty URLS" into URLs namespaced by a user prefix on the OpenFaaS API Gateway. 
+The router component is the only ingress point for HTTP requests for serving functions and for enabling the GitHub/GitLab integration. It translates "pretty URLS" into URLs namespaced by a user prefix on the OpenFaaS API Gateway.
 
 * Microservice: of-auth
 
@@ -144,7 +144,7 @@ Writes statuses to GitHub Checks API showing build status and URLs for endpoints
 
 * Function: garbage-collect
 
-Removes functions which were removed or renamed within the repo for the given user. Also responsible for handling requests to uninstall GitHub app from a repo or account.
+Removes functions which were removed or renamed within the repo for the given user. Also responsible for handling requests to uninstall GitHub/GitLab app from a repo or account.
 
 * Function: audit-event
 
@@ -156,12 +156,12 @@ Handler folder should be renamed to just `metrics`. Function can provide stats o
 
 ## Conceptual architecture diagram
 
-This conceptual diagram shows how OpenFaaS Cloud integrates with GitHub through the use of an event-driven architecture.
+This conceptual diagram shows how OpenFaaS Cloud integrates with GitHub/GitLab through the use of an event-driven architecture.
 
 Main flows:
 
-1. User pushes code - GitHub push event is sent to github-event function triggering a CI/CD workflow
-2. User removes GitHub app from one or more repos - garbage collection is invoked removing 1-many functions
+1. User pushes code - GitHub/GitLab push event is sent to github-event/gitlab-event function triggering a CI/CD workflow
+2. User removes GitHub/GitLab app from one or more repos - garbage collection is invoked removing 1-many functions
 3. User accesses function via router using "pretty URL" format and request is routed to function via API Gateway
 
 ![](./docs/conceptual-overview.png)

--- a/auth/README.md
+++ b/auth/README.md
@@ -41,7 +41,7 @@ Contents (encoded JWT):
 ## Building
 
 ```
-export TAG=0.3.1
+export TAG=0.4.0
 make
 ```
 
@@ -100,7 +100,7 @@ echo -n "$CLIENT_SECRET" | docker secret create of-client-secret -
 
 ```sh
 docker rm -f cloud-auth
-export TAG=0.3.1
+export TAG=0.4.0
 
 docker run \
  -e client_secret="$CLIENT_SECRET" \
@@ -111,6 +111,7 @@ docker run \
  -e cookie_root_domain=".system.gw.io" \
  -e public_key_path=/tmp/key.pub \
  -e private_key_path=/tmp/key \
+ -e oauth_provider="github" \
  -v "`pwd`/key:/tmp/key" \
  -v "`pwd`/key.pub:/tmp/key.pub" \
  --name cloud-auth  -ti openfaas/cloud-auth:${TAG}
@@ -123,7 +124,7 @@ Edit `yaml/core/of-auth-dep.yml` as needed and apply that file.
 ### On Swarm:
 
 ```sh
-export TAG=0.3.1
+export TAG=0.4.0
 docker service rm auth
 docker service create --name auth \
  -e oauth_client_secret_path="/run/secrets/of-client-secret" \
@@ -134,8 +135,17 @@ docker service create --name auth \
  -e cookie_root_domain=".system.gw.io" \
  -e public_key_path=/run/secrets/jwt-public-key \
  -e private_key_path=/run/secrets/jwt-private-key \
+ -e oauth_provider="github" \
  --secret jwt-private-key \
  --secret jwt-public-key \
  --secret of-client-secret \
  openfaas/cloud-auth:$TAG
+```
+
+### GitLab integration
+
+If you want to integrate OpenFaaS Cloud with your self-managed GitLab you need to set env variables, where instead of ... you should put valid url to your self-hosted GitLab (for example: https://gitlab.domain.com):
+```
+oauth_provider="gitlab"
+oauth_provider_base_url="..."
 ```

--- a/auth/handlers/common.go
+++ b/auth/handlers/common.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgrijalva/jwt-go"
 )
 
 // OpenFaaSCloudClaims extends standard claims
@@ -21,8 +21,8 @@ type OpenFaaSCloudClaims struct {
 	jwt.StandardClaims
 }
 
-// GitHubAccessToken as issued by GitHub
-type GitHubAccessToken struct {
+// ProviderAccessToken as issued by GitHub or GitLab
+type ProviderAccessToken struct {
 	AccessToken string `json:"access_token"`
 }
 
@@ -41,6 +41,25 @@ func buildGitHubURL(config *Config, resource string, scope string) *url.URL {
 	q.Set("redirect_uri", redirectURI)
 
 	u.RawQuery = q.Encode()
+	return u
+}
+
+func buildGitLabURL(config *Config) *url.URL {
+	authURL := config.OAuthProviderBaseURL + "/oauth/authorize"
+
+	u, _ := url.Parse(authURL)
+	q := u.Query()
+
+	q.Set("client_id", config.ClientID)
+	q.Set("response_type", "code")
+	q.Set("state", fmt.Sprintf("%d", time.Now().Unix()))
+
+	redirectURI := combineURL(config.ExternalRedirectDomain, "/oauth2/authorized")
+
+	q.Set("redirect_uri", redirectURI)
+
+	u.RawQuery = q.Encode()
+
 	return u
 }
 

--- a/auth/handlers/common_test.go
+++ b/auth/handlers/common_test.go
@@ -1,6 +1,10 @@
 package handlers
 
-import "testing"
+import (
+	"fmt"
+	"net/url"
+	"testing"
+)
 
 func TestCombineURL_BuildsValidURL(t *testing.T) {
 	want := "https://www.google.com/query/this"
@@ -9,5 +13,55 @@ func TestCombineURL_BuildsValidURL(t *testing.T) {
 	if want != got {
 		t.Errorf("combineURL want: %s, got: %s", want, got)
 		t.Fail()
+	}
+}
+
+func Test_buildGitLabURL(t *testing.T) {
+	c := &Config{
+		OAuthProviderBaseURL: "https://foo.bar",
+		ClientID: "baz",
+		ExternalRedirectDomain: "http://bazfoz.com",
+	}
+
+	expectedURL, _ := url.Parse(fmt.Sprintf(
+		"https://foo.bar/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s",
+		c.ClientID,
+		fmt.Sprintf("%s/oauth2/authorized", c.ExternalRedirectDomain),
+	))
+	expectedQuery := expectedURL.Query()
+
+	gotURL := buildGitLabURL(c)
+	gotQuery := gotURL.Query()
+
+	if expectedURL.Host != gotURL.Host {
+		t.Errorf("Expected host: \"%s\". Got: \"%s\"", expectedURL.Host, gotURL.Host)
+	}
+
+	if expectedURL.Path != gotURL.Path {
+		t.Errorf("Expected path: \"%s\". Got: \"%s\"", expectedURL.Path, gotURL.Path)
+	}
+
+	if expectedQuery.Get("response_type") != gotQuery.Get("response_type") {
+		t.Errorf(
+			"Expected query.response_type: \"%s\". Got: \"%s\"",
+			expectedQuery.Get("response_type"),
+			gotQuery.Get("response_type"),
+		)
+	}
+
+	if expectedQuery.Get("client_id") != gotQuery.Get("client_id") {
+		t.Errorf(
+			"Expected query.client_id: \"%s\". Got: \"%s\"",
+			expectedQuery.Get("client_id"),
+			gotQuery.Get("client_id"),
+		)
+	}
+
+	if expectedQuery.Get("redirect_uri") != gotQuery.Get("redirect_uri") {
+		t.Errorf(
+			"Expected query.redirect_uri: \"%s\". Got: \"%s\"",
+			expectedQuery.Get("redirect_uri"),
+			gotQuery.Get("redirect_uri"),
+		)
 	}
 }

--- a/auth/handlers/config.go
+++ b/auth/handlers/config.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Config struct {
+	OAuthProvider          string
+	OAuthProviderBaseURL   string
 	ClientID               string
 	ClientSecret           string
 	OAuthClientSecretPath  string // OAuthClientSecretPath when given overrides the ClientSecret env-var

--- a/auth/handlers/const.go
+++ b/auth/handlers/const.go
@@ -2,4 +2,6 @@ package handlers
 
 const (
 	cookieName = "openfaas_cloud_token"
+	gitlabName = "gitlab"
+	githubName = "github"
 )

--- a/auth/handlers/query.go
+++ b/auth/handlers/query.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -58,8 +59,18 @@ func MakeQueryHandler(config *Config, protected []string) func(http.ResponseWrit
 		log.Printf("Validate %s => %d\n", resource, status)
 
 		if status == http.StatusTemporaryRedirect {
-			redirect := buildGitHubURL(config, "", config.Scope)
-			log.Printf("Go to %s\n", redirect.String())
+			var redirect *url.URL
+
+			switch config.OAuthProvider {
+			case gitlabName:
+				redirect = buildGitLabURL(config)
+
+				break
+			case githubName:
+				redirect = buildGitHubURL(config, "", config.Scope)
+
+				break
+			}
 
 			http.Redirect(w, r, redirect.String(), http.StatusTemporaryRedirect)
 			return

--- a/auth/provider/github_profile.go
+++ b/auth/provider/github_profile.go
@@ -21,9 +21,10 @@ func NewGitHub(c *http.Client) *GitHub {
 }
 
 // GetProfile returns a profile for a user from GitHub
-func (gh *GitHub) GetProfile(accessToken string) (*GitHubProfile, error) {
+func (gh *GitHub) GetProfile(accessToken string) (*Profile, error) {
 	var err error
-	profile := &GitHubProfile{}
+	var githubProfile GitHubProfile
+	profile := &Profile{}
 
 	req, reqErr := http.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
 	req.Header.Add("Authorization", "token "+accessToken)
@@ -45,11 +46,18 @@ func (gh *GitHub) GetProfile(accessToken string) (*GitHubProfile, error) {
 
 		bytesOut, _ := ioutil.ReadAll(res.Body)
 
-		unmarshalErr := json.Unmarshal(bytesOut, profile)
+		unmarshalErr := json.Unmarshal(bytesOut, &githubProfile)
 		if unmarshalErr != nil {
 			return profile, unmarshalErr
 		}
 	}
+
+	profile.TwoFactor = githubProfile.TwoFactor
+	profile.Name = githubProfile.Name
+	profile.Email = githubProfile.Email
+	profile.CreatedAt = githubProfile.CreatedAt
+	profile.Login = githubProfile.Login
+	profile.ID = githubProfile.ID
 
 	return profile, err
 }

--- a/auth/provider/gitlab_profile.go
+++ b/auth/provider/gitlab_profile.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// GitLabProvider provider
+type GitLabProvider struct {
+	BaseURL string
+	ApiURL  string
+	Client  *http.Client
+}
+
+// NewGitLabProvider create a new GitLabProvider API provider
+func NewGitLabProvider(c *http.Client, baseURL string, apiURL string) *GitLabProvider {
+	return &GitLabProvider{
+		Client:  c,
+		BaseURL: baseURL,
+		ApiURL:  apiURL,
+	}
+}
+
+// GetProfile returns a profile for a user from GitLabProvider
+func (gl *GitLabProvider) GetProfile(accessToken string) (*Profile, error) {
+	var err error
+	var gitlabProfile GitLabProfile
+
+	req, reqErr := http.NewRequest(http.MethodGet, gl.ApiURL + "user", nil)
+	req.Header.Add("Authorization", "bearer "+accessToken)
+
+	if reqErr != nil {
+		return nil, reqErr
+	}
+
+	res, err := gl.Client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bad status code: %d", res.StatusCode)
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+
+		bytesOut, _ := ioutil.ReadAll(res.Body)
+
+		unmarshalErr := json.Unmarshal(bytesOut, &gitlabProfile)
+
+		if unmarshalErr != nil {
+			return nil, unmarshalErr
+		}
+	}
+
+	return &Profile{
+		ID:        gitlabProfile.ID,
+		Login:     gitlabProfile.Username,
+		CreatedAt: gitlabProfile.CreatedAt,
+		Email:     gitlabProfile.Email,
+		Name:      gitlabProfile.Name,
+		TwoFactor: gitlabProfile.TwoFactor,
+	}, err
+}
+
+// GitLabProfile represents a GitLabProvider profile
+type GitLabProfile struct {
+	ID        int       `json:"id"`
+	Username  string    `json:"username"`
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	TwoFactor bool      `json:"two_factor_enabled"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/auth/provider/types.go
+++ b/auth/provider/types.go
@@ -1,0 +1,45 @@
+package provider
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	githubName = "github"
+	gitlabName = "gitlab"
+)
+
+
+type Profile struct {
+	ID        int       `json:"id"`
+	Login     string    `json:"login"`
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	TwoFactor bool      `json:"two_factor"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type Provider interface {
+	GetProfile(accessToken string) (*Profile, error)
+}
+
+var supportedProviders = []string{
+	githubName,
+	gitlabName,
+}
+
+func GetSupportedString() {
+	strings.Join(supportedProviders, ", ")
+}
+
+func IsSupported(name string) bool {
+	for _, sp := range supportedProviders {
+		if strings.EqualFold(name, sp) {
+			return true
+		}
+	}
+
+	return false
+}
+

--- a/auth/provider/types_test.go
+++ b/auth/provider/types_test.go
@@ -1,0 +1,23 @@
+package provider
+
+import "testing"
+
+func TestSupportedProviders_IsSupported_whenProviderIsSupported(t *testing.T) {
+	if !IsSupported("github") {
+		t.Errorf("Want: \"%v\". Got: \"%v\"", true, false)
+	}
+
+	if !IsSupported("gitHub") {
+		t.Errorf("Want: \"%v\". Got: \"%v\"", true, false)
+	}
+
+	if !IsSupported("GitLab") {
+		t.Errorf("Want: \"%v\". Got: \"%v\"", true, false)
+	}
+}
+
+func TestSupportedProviders_IsSupported_whenProviderIsNotSupported(t *testing.T) {
+	if IsSupported("foobar.com") {
+		t.Errorf("Want: \"%v\". Got: \"%v\"", false, true)
+	}
+}

--- a/yaml/core/of-auth-dep.yml
+++ b/yaml/core/of-auth-dep.yml
@@ -24,7 +24,7 @@ spec:
             secretName: of-client-secret
       containers:
       - name: of-auth
-        image: openfaas/cloud-auth:0.3.1
+        image: openfaas/cloud-auth:0.4.0
         imagePullPolicy: Always
         env:
           - name: port
@@ -34,6 +34,10 @@ spec:
             value: ""
           - name: client_id
             value: ""
+          - name: oauth_provider_base_url
+            value: "" # If you want to use GitLab, put here address of it. For example: https://gitlab.domain.com
+          - name: oauth_provider
+            value: "github"
 # Local test config
           # - name: external_redirect_domain
           #   value: "http://auth.system.gw.io:8081"


### PR DESCRIPTION
Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
- Implemented GitLab as OAuth 2 Provider for authorisation
- Modified kubernetes template for of-auth with additional env vars:
  oauth_provider_base_url and oauth_provider

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have created two OAuth applications, one on GitHub and second one on my own instance of GitLab on https://gitlab.dedal.io and then tried do go to protected path (dashboard) using GitLab as a provider and then I have removed cookie, changed properties inside yaml/core/of-auth-dep.yml for GitHub application as a Provider and tried again.

## How are existing users impacted? What migration steps/scripts do we need?
There is no need to do migration. There is no impact for existing users, everything should work as it was before if they want to use GitHub as a provider of OAuth or without authorisation.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
