### PR TITLE
Edit findStackFile to form raw URL depending on GitHub/GitLab

### DIFF
--- a/git-tar/function/handler_test.go
+++ b/git-tar/function/handler_test.go
@@ -1,0 +1,53 @@
+package function
+
+import (
+	"testing"
+)
+
+func Test_getRawURL(t *testing.T) {
+	var pushEvents = []struct {
+		RepositoryURL        string
+		RepositoryOwnerLogin string
+		RepositoryName       string
+		AfterCommitID        string
+		SCM                  string
+		Expected             string
+	}{
+		{
+			RepositoryURL:        "",
+			RepositoryOwnerLogin: "myuser",
+			RepositoryName:       "myrepo",
+			SCM:                  "github",
+			Expected:             "https://raw.githubusercontent.com/myuser/myrepo/master/stack.yml",
+		},
+		{
+			RepositoryURL:        "",
+			RepositoryOwnerLogin: "myuser",
+			RepositoryName:       "myrepo",
+			SCM:                  "github",
+			Expected:             "https://raw.githubusercontent.com/myuser/myrepo/master/stack.yml",
+		},
+		{
+			RepositoryURL:        "https://gitlab.url.io",
+			RepositoryOwnerLogin: "myuser",
+			RepositoryName:       "myrepo",
+			SCM:                  "gitlab",
+			Expected:             "https://gitlab.url.io/myuser/myrepo/raw/master/stack.yml",
+		},
+		{
+			RepositoryURL:        "https://gitlab.url.io",
+			RepositoryOwnerLogin: "myuser",
+			RepositoryName:       "myrepo",
+			SCM:                  "gitlab",
+			Expected:             "https://gitlab.url.io/myuser/myrepo/raw/master/stack.yml",
+		},
+	}
+
+	for _, pushEvent := range pushEvents {
+		addr, _ := getRawURL(pushEvent.SCM, pushEvent.RepositoryURL, pushEvent.RepositoryOwnerLogin, pushEvent.RepositoryName)
+		if addr != pushEvent.Expected {
+			t.Errorf("Want \"%s\", got \"%s\"", pushEvent.Expected, addr)
+		}
+	}
+
+}

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -11,7 +11,8 @@ type PushEventRepository struct {
 	CloneURL string `json:"clone_url"`
 	Private  bool   `json:"private"`
 
-	Owner Owner `json:"owner"`
+	Owner         Owner  `json:"owner"`
+	RepositoryURL string `json:"url"`
 }
 
 type PushEvent struct {


### PR DESCRIPTION
The raw URL for stack.yml was previously supporting only GitHub, so the build was failing for GitLab. With this change raw URL is properly formed depending on the git hosting solution  (GitHub/GitLab)

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes #276

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by @martindekov on GitLab
I tested on GitHub:
1. Succeeds when stack.yml is available
2. Fails when not with `unable to find stack.yml`
3. After reproducing error with empty raw url (by using an image for `github-push` without the changes) fails with `given stack file raw URL is empty`. This resolves previous problem in behaviour - if fileSTackFile fails with error, there were no status reported.

## How are existing users impacted? What migration steps/scripts do we need?
Not impacted


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A