### PR TITLE
Expose /logout endpoint

### DIFF
--- a/auth/handlers/logout.go
+++ b/auth/handlers/logout.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+)
+
+// MakeLoginHandler creates a handler for logging out
+func MakeLogoutHandler(config *Config) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			HttpOnly: true,
+			Name:     cookieName,
+			Value:    "",
+			Path:     "/",
+			Expires:  time.Unix(0, 0),
+			Domain:   config.CookieRootDomain,
+		})
+
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/auth/main.go
+++ b/auth/main.go
@@ -86,6 +86,7 @@ func main() {
 
 	router.HandleFunc("/q/", handlers.MakeQueryHandler(config, protected))
 	router.HandleFunc("/login/", handlers.MakeLoginHandler(config))
+	router.HandleFunc("/logout/", handlers.MakeLogoutHandler(config))
 	router.HandleFunc("/oauth2/", handlers.MakeOAuth2Handler(config))
 	router.HandleFunc("/healthz/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
Closes: https://github.com/openfaas/openfaas-cloud/issues/283

Exposed /logout endpoint will remove openfaas_cloud_token cookie

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually used endpoint to remove cookie few times.

## How are existing users impacted? What migration steps/scripts do we need?
They are not.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
