### PR TITLE
Add struct to sdk that handles GitLab payload

### DIFF
--- a/sdk/events.go
+++ b/sdk/events.go
@@ -41,6 +41,28 @@ type Event struct {
 	Private        bool              `json:"private"`
 }
 
+// PushEvent as received from GitLab
+
+type GitLabPushEvent struct {
+	Ref              string           `json:"ref"`
+	UserUsername     string           `json:"user_username"`
+	UserEmail        string           `json:"user_email"`
+	GitLabProject    GitLabProject    `json:"project"`
+	GitLabRepository GitLabRepository `json:"repository"`
+	AfterCommitID    string           `json:"after"`
+}
+
+type GitLabProject struct {
+	ID                int    `json:"id"`
+	Namespace         string `json:"namespace"`
+	Name              string `json:"name"`
+	PathWithNamespace string `json:"path_with_namespace"` //would be repo full name
+}
+
+type GitLabRepository struct {
+	CloneURL string `json:"git_http_url"`
+}
+
 type Customer struct {
 	Sender Sender `json:"sender"`
 }


### PR DESCRIPTION
Adding struct that handles GitLab payload cause currently
PR #109 that handles push events from GitLab use copied
vendor folder which is not the right way to vendor code
the PR above need proper vendoring

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Currently PR #109 "vendors" GitLab sdk by copying `vendor` folder from other project and add the struct manually and I would like to vendor the code the proper way so when this PR is merged and new release of SDK is made I can make code in the above PR vendored properly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A. Exist in PR #109 and used multiple times for testing but in the PR the change is "vendored" by copying the vendor folder from other projects.

## How are existing users impacted? What migration steps/scripts do we need?

N.A. this is part of bigger change

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
