### PR TITLE
Add SCM field to PushEvent and Event struct

### DIFF
--- a/sdk/events.go
+++ b/sdk/events.go
@@ -15,6 +15,7 @@ type PushEventRepository struct {
 }
 
 type PushEvent struct {
+	SCM           string
 	Ref           string `json:"ref"`
 	Repository    PushEventRepository
 	AfterCommitID string `json:"after"`
@@ -39,6 +40,7 @@ type Event struct {
 	Environment    map[string]string `json:"environment"`
 	Secrets        []string          `json:"secrets"`
 	Private        bool              `json:"private"`
+	SCM            string            `json:"scm"`
 }
 
 type Customer struct {


### PR DESCRIPTION
Addding SCM field to the PushEvent and Event struct so
that the functions down the line know what is the
source of the event and construct/invoke/do things
specific for the SCM mentioned

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Add SCM field to the `PushEvent` and `Event` struct to be manually populated by the github/gitlab-push functions so functions down the line know how to transform the struct for the specific SCM. Also potentially adding the field to list-functions etc.

Part of #210 

Should be re-vendored in `github-push` && `git-tar` && `buildshiprun`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A. just adding the struct so the change can properly released and vendored

## How are existing users impacted? What migration steps/scripts do we need?

N.A. adding field in struct

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
