### PR TITLE
Integrate whole repoURL

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -193,6 +193,7 @@ func Handle(req []byte) string {
 				sdk.FunctionLabelPrefix + "git-sha":        event.SHA,
 				sdk.FunctionLabelPrefix + "git-private":    fmt.Sprintf("%d", private),
 				sdk.FunctionLabelPrefix + "git-scm":        event.SCM,
+				sdk.FunctionLabelPrefix + "git-repo-url":   event.RepoURL,
 				"faas_function":                            serviceValue,
 				"app":                                      serviceValue,
 				"com.openfaas.scale.min": scalingMinLimit,
@@ -298,6 +299,7 @@ func getEvent() (*sdk.Event, error) {
 	info.Image = os.Getenv("Http_Image")
 	info.SCM = os.Getenv("Http_Scm")
 	info.Private, _ = strconv.ParseBool(os.Getenv("Http_Private"))
+	info.RepoURL = os.Getenv("Http_Repo_Url")
 
 	if len(os.Getenv("Http_Installation_id")) > 0 {
 		info.InstallationID, err = strconv.Atoi(os.Getenv("Http_Installation_id"))

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -11,7 +11,8 @@ type PushEventRepository struct {
 	CloneURL string `json:"clone_url"`
 	Private  bool   `json:"private"`
 
-	Owner Owner `json:"owner"`
+	Owner         Owner  `json:"owner"`
+	RepositoryURL string `json:"url"`
 }
 
 type PushEvent struct {
@@ -40,6 +41,7 @@ type Event struct {
 	Secrets        []string          `json:"secrets"`
 	Private        bool              `json:"private"`
 	SCM            string            `json:"scm"`
+	RepoURL        string            `json:"repourl"`
 }
 
 // BuildEventFromPushEvent function to build Event from PushEvent

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -314,6 +314,7 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services, sta
 	installationID := pushEvent.Installation.ID
 	sourceManagement := pushEvent.SCM
 	privateRepo := pushEvent.Repository.Private
+	repositoryURL := pushEvent.Repository.RepositoryURL
 
 	c := http.Client{}
 	gatewayURL := os.Getenv("gateway_url")
@@ -372,6 +373,7 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services, sta
 		httpReq.Header.Add("Sha", afterCommitID)
 		httpReq.Header.Add("Scm", sourceManagement)
 		httpReq.Header.Add("Private", strconv.FormatBool(privateRepo))
+		httpReq.Header.Add("Repo-URL", repositoryURL)
 
 		envJSON, marshalErr := json.Marshal(stack.Functions[tarEntry.functionName].Environment)
 		if marshalErr != nil {

--- a/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/git-tar/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -11,7 +11,8 @@ type PushEventRepository struct {
 	CloneURL string `json:"clone_url"`
 	Private  bool   `json:"private"`
 
-	Owner Owner `json:"owner"`
+	Owner         Owner  `json:"owner"`
+	RepositoryURL string `json:"url"`
 }
 
 type PushEvent struct {

--- a/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/github-push/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -11,7 +11,8 @@ type PushEventRepository struct {
 	CloneURL string `json:"clone_url"`
 	Private  bool   `json:"private"`
 
-	Owner Owner `json:"owner"`
+	Owner         Owner  `json:"owner"`
+	RepositoryURL string `json:"url"`
 }
 
 type PushEvent struct {


### PR DESCRIPTION
In previous PR #270 I added the whole URL to the SDK
and this PR implements the change to be given to
`list-functions`

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Implements change #270 so the whole URL of the repository is handled then passed down instead of constructed in dashboard. Also possibly constructing URL for raw file in git-tar for future PR.

References #224 and in case integrated into the dashboard will close the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TO DO:
Testing
Re-vendoring after #270 is merged/released

## How are existing users impacted? What migration steps/scripts do we need?

Maybe redeploying dashboard in case people move version forward if the change is merged and changes on dashboard are applied.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
