### PR TITLE
Adjust private repo indication with new label + icon in details

### DIFF
--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -63,8 +63,8 @@ class FunctionsApi {
       let isPrivate = false;
 
       if (
-        item.labels['com.openfaas.cloud.git-private-repo'] &&
-        item.labels['com.openfaas.cloud.git-private-repo'] === 'true'
+        item.labels['com.openfaas.cloud.git-private'] &&
+        item.labels['com.openfaas.cloud.git-private'] === '1'
       ) {
         isPrivate = true;
       }

--- a/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
+++ b/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAward } from '@fortawesome/free-solid-svg-icons';
+import { faAward, faUserSecret } from '@fortawesome/free-solid-svg-icons';
 
 import { FunctionOverviewPanel } from '../FunctionOverviewPanel'
 import { ReplicasProgress } from "../ReplicasProgress";
@@ -93,7 +93,12 @@ const FunctionDetailSummary = ({ fn, handleShowBadgeModal }) => {
   ];
 
   const deployIcon = <FontAwesomeIcon icon="info-circle" className="mr-3" />;
-  const gitIcon = <FontAwesomeIcon icon="code-branch" className="mr-3" />;
+  const gitIcon = (
+    <span>
+      <FontAwesomeIcon icon="code-branch" className="mr-3" />
+      { fn.gitPrivate && <FontAwesomeIcon icon={faUserSecret} className="mr-3" /> }
+    </span>
+  );
   const invocationsIcon = <FontAwesomeIcon icon="bolt" className="mr-3 mr-lg-2 d-inline-block d-lg-none d-xl-inline-block" />;
   const deployButton = (
     <Button outline color="secondary" size="xs" tag={Link} to={to}>


### PR DESCRIPTION
Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
Changed label's name from `git-private-repo` to `git-private` in functionsApi
Added private repo icon inside function details page at the header
of `Git` card

Closes https://github.com/openfaas/openfaas-cloud/issues/299

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed private and public function on my OpenFaaS Cloud cluster and checked if private repo icon is present in function list and function details page

## How are existing users impacted? What migration steps/scripts do we need?
Private functions needs to be redeployed to indicate that they are private
1. Commit and push any change to functions repository, and when it will be deployed it should be correctly marked as private.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
