### PR TITLE
Edit source management to github

### DIFF
--- a/github-push/handler.go
+++ b/github-push/handler.go
@@ -18,6 +18,9 @@ import (
 // Source name for this function when auditing
 const Source = "github-push"
 
+//SCM identifier
+const SCM = "github"
+
 var audit sdk.Audit
 
 // Handle a serverless request
@@ -61,7 +64,7 @@ func Handle(req []byte) string {
 		return err.Error()
 	}
 
-	pushEvent.SCM = Source
+	pushEvent.SCM = SCM
 
 	var found bool
 


### PR DESCRIPTION
This edits the SCM field to be only github, as it was previously
using the function name `github-push`

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added log message in github-push and buildshiprun code  for testing,
updated the images to `docwareiy/github-push:scm_t` and `docwareiy/of-buildshiprun:scm_t`

And checked the logs:

```
github-push.1.zfz74irdt5vo@FaasSwarm    | Scm field is :`github`
```

```
buildshiprun.1.qekauz73uja7@FaasSwarm    | Scm field is :`github`
```

Build was successful too.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests