### PR TITLE
Ammend little fix with raw stack optimisation

### DIFF
--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -308,19 +308,17 @@ func findStackFile(pushEvent *sdk.PushEvent) (bool, error) {
 
 func getRawURL(scm string, repositoryURL string, repositoryOwnerLogin string, repositoryName string) (string, error) {
 
-	addrPrefix := ""
-	rawPath := ""
+	rawURL := ""
 	switch scm {
 	case "github":
-		addrPrefix = "https://raw.githubusercontent.com"
+		rawURL = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/master/stack.yml", repositoryOwnerLogin, repositoryName)
 	case "gitlab":
-		addrPrefix = repositoryURL
-		rawPath = "raw/"
+		rawURL = fmt.Sprintf("%s/raw/master/stack.yml", repositoryURL)
 	}
-	if addrPrefix == "" {
+	if rawURL == "" {
 		return "", fmt.Errorf(`failed to find stack.yml file: cannot form proper raw URL.
 			Expected pushEvent.SCM to be "github" or "gitlab", but got %s`, scm)
 	}
 
-	return fmt.Sprintf("%s/%s/%s/%smaster/stack.yml", addrPrefix, repositoryOwnerLogin, repositoryName, rawPath), nil
+	return rawURL, nil
 }

--- a/git-tar/function/handler_test.go
+++ b/git-tar/function/handler_test.go
@@ -14,28 +14,28 @@ func Test_getRawURL(t *testing.T) {
 		Expected             string
 	}{
 		{
-			RepositoryURL:        "",
+			RepositoryURL:        "https://gitlab.url.io/myuser/myrepo",
 			RepositoryOwnerLogin: "myuser",
 			RepositoryName:       "myrepo",
 			SCM:                  "github",
 			Expected:             "https://raw.githubusercontent.com/myuser/myrepo/master/stack.yml",
 		},
 		{
-			RepositoryURL:        "",
+			RepositoryURL:        "https://gitlab.url.io/myuser/myrepo",
 			RepositoryOwnerLogin: "myuser",
 			RepositoryName:       "myrepo",
 			SCM:                  "github",
 			Expected:             "https://raw.githubusercontent.com/myuser/myrepo/master/stack.yml",
 		},
 		{
-			RepositoryURL:        "https://gitlab.url.io",
+			RepositoryURL:        "https://gitlab.url.io/myuser/myrepo",
 			RepositoryOwnerLogin: "myuser",
 			RepositoryName:       "myrepo",
 			SCM:                  "gitlab",
 			Expected:             "https://gitlab.url.io/myuser/myrepo/raw/master/stack.yml",
 		},
 		{
-			RepositoryURL:        "https://gitlab.url.io",
+			RepositoryURL:        "https://gitlab.url.io/myuser/myrepo",
 			RepositoryOwnerLogin: "myuser",
 			RepositoryName:       "myrepo",
 			SCM:                  "gitlab",


### PR DESCRIPTION
Adding couple of fixes because the url was not formatted
right because I gave misleading instructions on how gitlab
formats its URL

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

I needed a change for gitlab, but gave misleading instructions on how gitlab URL was formatted So this fix addresses those.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Successfully built and deployed functions on my instance with gitlab and github here are the logs:
GitHub:
```
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:32:31 Version: 0.9.5	SHA: 3598da2e513a09a6b8ce6e17c6baa3558a4c8d11
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:32:31 Read/write timeout: 15m0s, 15m0s. Port: 8080
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:32:31 Writing lock-file to: /tmp/.lock
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:06 Forking fprocess.
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:06 Query  
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:06 Path  /
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:06 Stack file request: https://raw.githubusercontent.com/martindekov/gocloudfunc/master/stack.yml
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:06 Stack file status: 200
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:06 /tmp/martindekov
git-tar.1.gginir6ndc1o@FaasSwarm    | Tar up /tmp/martindekov/gocloudfunc
git-tar.1.gginir6ndc1o@FaasSwarm    | Creating tar for:  ./gocloudfunc gocloudfunc
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc/Dockerfile
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc/config
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc/function
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc/function/handler.go
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc/main.go
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:11 /tmp/martindekov/gocloudfunc/build/gocloudfunc/template.yml
git-tar.1.gginir6ndc1o@FaasSwarm    | Deploying service - gocloudfunc
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:12 Building gocloudfunc. Tar: 8K
git-tar.1.gginir6ndc1o@FaasSwarm    | Service deployed  gocloudfunc 200 OK martindekov
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:48 Functions owned by martindekov:
git-tar.1.gginir6ndc1o@FaasSwarm    |  [{martindekov-gocloudfunc martindekov-gocloudfunc-gocloudfunc:latest-597466c map[app:martindekov-gocloudfunc com.openfaas.function:martindekov-gocloudfunc faas_function:martindekov-gocloudfunc function:true com.openfaas.cloud.git-cloud:1 com.openfaas.cloud.git-owner:martindekov com.openfaas.cloud.git-repo:gocloudfunc com.openfaas.cloud.git-sha:597466c795cf4f9a89cc1cbdaadb1d452735c56c com.openfaas.scale.max:4 com.openfaas.scale.min:1 com.openfaas.cloud.git-deploytime:1539869685 com.openfaas.cloud.git-private:0 com.openfaas.cloud.git-repo-url:https://github.com/martindekov/gocloudfunc com.openfaas.cloud.git-scm:github]}]Garbage collection ran for martindekov/gocloudfunc - 0 functions deleted.
git-tar.1.gginir6ndc1o@FaasSwarm    | 
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:34:48 Duration: 42.030989 seconds
```
GitLab:
```
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:42 Forking fprocess.
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:42 Query  
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:42 Path  /
git-tar.1.gginir6ndc1o@FaasSwarm    | Deployed: gocloudfunc @ docker.io/martindekov/martindekov-gocloudfunc-gocloudfunc:latest-597466c. Took 42.002289304s2018/10/18 13:36:42 Stack file request: https://gitlab.dedal.io/martindekov/gitlab-playground/raw/master/stack.yml
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:43 Stack file status: 200
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:43 /tmp/martindekov
git-tar.1.gginir6ndc1o@FaasSwarm    | Tar up /tmp/martindekov/gitlab-playground
git-tar.1.gginir6ndc1o@FaasSwarm    | Creating tar for:  ./playground playground
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground/Dockerfile
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground/config
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground/function
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground/function/handler.go
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground/main.go
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:46 /tmp/martindekov/gitlab-playground/build/playground/template.yml
git-tar.1.gginir6ndc1o@FaasSwarm    | Deploying service - playground
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:47 failed to report status, error: failed to call github-status, invalid status: 500 Internal Server Error
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:36:47 Building playground. Tar: 8K
git-tar.1.gginir6ndc1o@FaasSwarm    | Service deployed  playground 200 OK martindekov
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:37:22 failed to report status, error: failed to call github-status, invalid status: 500 Internal Server Error
git-tar.1.gginir6ndc1o@FaasSwarm    | 2018/10/18 13:37:22 Functions owned by martindekov:
git-tar.1.gginir6ndc1o@FaasSwarm    |  [{martindekov-gocloudfunc martindekov-gocloudfunc-gocloudfunc:latest-597466c map[com.openfaas.cloud.git-owner:martindekov faas_function:martindekov-gocloudfunc com.openfaas.cloud.git-deploytime:1539869685 com.openfaas.cloud.git-scm:github com.openfaas.cloud.git-sha:597466c795cf4f9a89cc1cbdaadb1d452735c56c com.openfaas.function:martindekov-gocloudfunc app:martindekov-gocloudfunc com.openfaas.cloud.git-private:0 com.openfaas.scale.max:4 com.openfaas.cloud.git-cloud:1 com.openfaas.cloud.git-repo:gocloudfunc com.openfaas.cloud.git-repo-url:https://github.com/martindekov/gocloudfunc com.openfaas.scale.min:1 function:true]} {martindekov-playground martindekov-gitlab-playground-playground:latest-47551e9 map[com.openfaas.function:martindekov-playground faas_function:martindekov-playground com.openfaas.cloud.git-cloud:1 com.openfaas.cloud.git-sha:47551e9b454d92972c3e2ead027b0d82a0110a20 com.openfaas.scale.max:4 com.openfaas.cloud.git-owner:martindekov com.openfaas.cloud.git-repo-url:https://gitlab.dedal.io/martindekov/gitlab-playground com.openfaas.cloud.git-scm:gitlab function:true app:martindekov-playground com.openfaas.cloud.git-deploytime:1539869840 com.openfaas.cloud.git-private:0 com.openfaas.cloud.git-repo:gitlab-playground com.openfaas.scale.min:1]}]Garbage collection ran for martindekov/gitlab-playground - 0 functions deleted.

```

## How are existing users impacted? What migration steps/scripts do we need?

N.A.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
