### PR TITLE
Support repository urls from different SCMs in Dashboard

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -24,7 +24,8 @@ $ faas-cli store deploy figlet --name alexellis-figlet --label Git-Owner=alexell
  --label com.openfaas.cloud.git-sha=665d9597547d8e0425630ba2dbb73c2951a61ce2 \
  --label com.openfaas.cloud.git-deploytime=1533026741 \
  --label com.openfaas.cloud.git-cloud=1 --network=func_functions \
- --label com.openfaas.scale.min=1 --label com.openfaas.scale.max=4
+ --label com.openfaas.scale.min=1 --label com.openfaas.scale.max=4 \
+ --annotation com.openfaas.cloud.git-repo-url=https://github.com/alexellis/figlet
 ```
 
 ```
@@ -34,7 +35,8 @@ $ faas-cli store deploy nodeinfo --name alexellis-nodeinfo \
  --label com.openfaas.cloud.git-sha=665d9597547d8e0425630ba2dbb73c2951a61ce2 \
  --label com.openfaas.cloud.git-deploytime=1533026741 \
  --label com.openfaas.cloud.git-cloud=1 \
- --label com.openfaas.scale.min=1 --label com.openfaas.scale.max=4 --network=func_functions
+ --label com.openfaas.scale.min=1 --label com.openfaas.scale.max=4 --network=func_functions \
+ --annotation com.openfaas.cloud.git-repo-url=https://github.com/alexellis/nodeinfo
 ```
 
 ### Deploy at least the list-functions function

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import moment from 'moment';
 
+const getRepoURL = annotations => annotations['com.openfaas.cloud.git-repo-url'] || '';
+
 class FunctionsApi {
   constructor() {
     this.selectedRepo = '';
@@ -83,6 +85,7 @@ class FunctionsApi {
         gitDeployTime: item.labels['com.openfaas.cloud.git-deploytime'],
         gitPrivate: isPrivate,
         gitSha: item.labels['com.openfaas.cloud.git-sha'],
+        gitRepoURL: getRepoURL(item.annotations || {}),
         minReplicas: item.labels['com.openfaas.scale.min'],
         maxReplicas: item.labels['com.openfaas.scale.max'],
       };

--- a/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
+++ b/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
@@ -78,7 +78,7 @@ const FunctionDetailSummary = ({ fn, handleShowBadgeModal }) => {
       renderValue() {
         return (
           <a
-            href={`https://github.com/${repo}/commit/${fn.gitSha}`}
+            href={`${fn.gitRepoURL}/commit/${fn.gitSha}`}
             target="_blank"
           >
             { fn.gitSha }

--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -13,8 +13,8 @@ const genFnDetailPath = ({ shortName, gitOwner, gitRepo }, user) => (
   `${user}/${shortName}?repoPath=${gitOwner}/${gitRepo}`
 );
 
-const genRepoUrl = ({ gitOwner, gitRepo }) => (
-  `https://github.com/${gitOwner}/${gitRepo}/commits/master`
+const genRepoUrl = ({ gitOwner, gitRepoURL }) => (
+  `${gitRepoURL}/commits/master`
 );
 
 const FunctionTableItem = ({ onClick, fn, user }) => {


### PR DESCRIPTION
Closes https://github.com/openfaas/openfaas-cloud/issues/304

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
Added support to other SCM's as repository urls inside Dashboard

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed to my cluster and tested with functions on GitHub and my own GitLab instance.


## How are existing users impacted? What migration steps/scripts do we need?
They are not


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
