### PR TITLE
Use http_proxy/https_proxy build-arg when set in of-builder

### DIFF
--- a/yaml/core/of-builder-dep.yml
+++ b/yaml/core/of-builder-dep.yml
@@ -21,7 +21,7 @@ spec:
             secretName: payload-secret
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.6.0
+        image: openfaas/of-builder:0.6.1
         imagePullPolicy: Always
         env:
           - name: enable_lchown


### PR DESCRIPTION
Closes https://github.com/openfaas/openfaas-cloud/issues/310

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
If you pass to of-builder env vars http_proxy and/or https_proxy
they will be passed to buildkit

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added variables `http_proxy` and `https_proxy` and tried to rebuild function. It tried to use proxy, but because I don't have an access to valid proxy I had to put fake data. Build failed with log:
```
curl: (5) Could not resolve proxy: some_fake_proxy_address
``` 
@WTFKr0 it would be good if you could test it with valid proxy

## How are existing users impacted? What migration steps/scripts do we need?
There is no need to do migration.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
