### PR TITLE
Add WebURL and VisibilityLevel to struct

### DIFF
--- a/sdk/events_scm.go
+++ b/sdk/events_scm.go
@@ -47,6 +47,8 @@ type GitLabProject struct {
 	Namespace         string `json:"namespace"`
 	Name              string `json:"name"`
 	PathWithNamespace string `json:"path_with_namespace"` //would be repo full name
+	WebURL            string `json:"web_url"`
+	VisibilityLevel   int    `json:"visibility_level"`
 }
 
 type GitLabRepository struct {


### PR DESCRIPTION
Adding two fields to the GitLab SDK to be vendored
in the GitLab functions

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Two fields added to the structures in the SDK to be released/re-vendored into my code which are for private repositories and whole URL

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A. It is a struct

## How are existing users impacted? What migration steps/scripts do we need?

N.A.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
