### PR TITLE
Bump version of of-builder in repository

### DIFF
--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -92,14 +92,14 @@ The builder service calls into the buildkit daemon to build an OpenFaaS function
 ### Build
 
 ```sh
-export OF_BUILDER_TAG=0.5.3
+export OF_BUILDER_TAG=0.6.1
 make build push
 ```
 
 ### Deploy
 
 ```
-export OF_BUILDER_TAG=0.5.3
+export OF_BUILDER_TAG=0.6.1
 docker service create \
  --network func_functions \
  --name of-builder \

--- a/of-builder/deploy_swarm.sh
+++ b/of-builder/deploy_swarm.sh
@@ -12,7 +12,7 @@ docker run -d --net func_functions -d --privileged \
 --restart always \
 --name of-buildkit alexellis2/buildkit:2018-04-17 --addr tcp://0.0.0.0:1234
 
-export OF_BUILDER_TAG=0.5.3
+export OF_BUILDER_TAG=0.6.1
 
 # You should mount your .docker/config.json file here, but first make sure it is
 # readable. `chmod 777 $HOME/.docker/config.json`


### PR DESCRIPTION
Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
Bumped version of of-builder to 0.6.1 (the latest one)
inside of of-builder/README.md and of-builder/deploy_swarm.sh

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just visually, looked inside repository for any mention of `openfaas/cloud-router`

## How are existing users impacted? What migration steps/scripts do we need?
Users should check if they are using the newest version of `of-builder` (which is `0.6.1`) and if don't they should redeploy theirs `of-builder`


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
