### PR TITLE
Amend fix to CreateServiceURL in sdk

### DIFF
--- a/sdk/service.go
+++ b/sdk/service.go
@@ -10,7 +10,7 @@ func FormatServiceName(owner, functionName string) string {
 }
 
 func CreateServiceURL(URL, suffix string) string {
-	if len(suffix) == 0 {
+	if strings.Contains(URL, suffix) {
 		return URL
 	}
 	columns := strings.Count(URL, ":")

--- a/sdk/service_test.go
+++ b/sdk/service_test.go
@@ -59,6 +59,18 @@ func Test_CreateServiceURL(t *testing.T) {
 			expectedURL: "http://gateway.openfaas:8080",
 		},
 		{
+			title:       "URL formatted for Kubernetes showing backward compatability",
+			URL:         "http://gateway.openfaas:8080",
+			suffix:      "openfaas",
+			expectedURL: "http://gateway.openfaas:8080",
+		},
+		{
+			title:       "URL formatted for Kubernetes showing backward compatability when suffix is not present",
+			URL:         "http://gateway.openfaas:8080",
+			suffix:      "",
+			expectedURL: "http://gateway.openfaas:8080",
+		},
+		{
 			title:       "URL formatted for Swarm without port",
 			URL:         "http://gateway",
 			suffix:      "",


### PR DESCRIPTION
Adding backwards compatability to the CreateServiceURL
function in case users have the change but do not have the
`dns_suffix` variable set

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Extends PR #198 by adding backward compatibility to the function in the SDK and add additional test showing the change

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

Adds backwards compatibility to gateway configuration for when OpenFaaS Cloud is on Kubernetes

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
