### PR TITLE
Added Run on my OpenFaaS functionality

### DIFF
--- a/dashboard/client/src/App.css
+++ b/dashboard/client/src/App.css
@@ -162,6 +162,7 @@ a {
 }
 
 .valid-tooltip {
-    top: -100%;
-    right: 0;
+    top: initial;
+    bottom: 5px;
+    left: 5px;
 }

--- a/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
+++ b/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAward, faUserSecret } from '@fortawesome/free-solid-svg-icons';
+import { faAward, faCloudDownloadAlt, faUserSecret } from '@fortawesome/free-solid-svg-icons';
 
 import { FunctionOverviewPanel } from '../FunctionOverviewPanel'
 import { ReplicasProgress } from "../ReplicasProgress";
@@ -27,7 +27,7 @@ const renderContainerImage = image => {
   }
 };
 
-const FunctionDetailSummary = ({ fn, handleShowBadgeModal }) => {
+const FunctionDetailSummary = ({ fn, handleShowBadgeModal, handleShowRunOnMyOFModal }) => {
   const to = `${fn.shortName}/log?repoPath=${fn.gitOwner}/${
     fn.gitRepo
   }&commitSHA=${fn.gitSha}`;
@@ -36,7 +36,20 @@ const FunctionDetailSummary = ({ fn, handleShowBadgeModal }) => {
   const deployMeta = [
     {
       label: 'Name:',
-      value: fn.shortName,
+      renderValue() {
+        return (
+          <div className="d-flex align-items-start">
+            <div>
+            { fn.shortName }
+            </div>
+            <div className="ml-auto">
+              <Button outline size="xs" title="Run on my OpenFaaS" onClick={handleShowRunOnMyOFModal}>
+                <FontAwesomeIcon icon={faCloudDownloadAlt} />
+              </Button>
+            </div>
+          </div>
+        )
+      },
     },
     {
       label: 'Image:',

--- a/dashboard/client/src/components/ModalRunOnMyOF/ModalRunOnMyOF.jsx
+++ b/dashboard/client/src/components/ModalRunOnMyOF/ModalRunOnMyOF.jsx
@@ -1,0 +1,118 @@
+import React, { Component } from 'react';
+import {
+  Modal,
+  ModalBody,
+  ModalHeader,
+  FormFeedback,
+  Form,
+  Input,
+  Button,
+  Row,
+  Col,
+} from 'reactstrap';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+
+class ModalRunOnMyOF extends Component {
+  state = {
+    valid: false,
+  };
+
+  constructor() {
+    super();
+
+    this.handleCopyClick = this.handleCopyClick.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+  }
+
+  handleCopyClick(e) {
+    e.preventDefault();
+
+    this.input.select();
+
+    document.execCommand('copy');
+
+    this.setState({
+      valid: true,
+    }, () => {
+      setTimeout(() => {
+        this.setState({
+          valid: false,
+        })
+      }, 1500)
+    })
+  };
+
+  closeModal() {
+    this.setState({ active: false });
+  }
+
+  render() {
+    const { shortName, image, gitOwner } = this.props.fn;
+    const code = `{
+mkdir -p /tmp/openfaas-cloud/${gitOwner}/${shortName}/
+cd /tmp/openfaas-cloud/${gitOwner}/${shortName}/
+
+cat > stack.yml <<EOF
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  ${shortName}:
+    skip_build: true
+    image: ${ image }
+EOF
+
+faas-cli deploy
+}`;
+
+    return (
+      <Modal isOpen={this.props.state} toggle={this.props.closeModal} className={this.props.className}>
+        <ModalHeader toggle={this.props.closeModal}>
+          Run on my <strong>OpenFaaS</strong>
+        </ModalHeader>
+        <ModalBody>
+          <p>
+            To run this function on your local <strong>OpenFaaS</strong> cluster copy and paste the below into a bash terminal.
+          </p>
+          <Form>
+            <Row noGutters className="align-items-end">
+              <Col>
+                <Input
+                  readOnly
+                  className="text-monospace"
+                  innerRef={(node) => {
+                    this.input = node;
+                  }}
+                  type="textarea"
+                  valid={this.state.valid}
+                  value={code}
+                  bsSize="sm"
+                  rows="8"
+                />
+                <FormFeedback valid tooltip>
+                  Copied to clipboard
+                </FormFeedback>
+              </Col>
+              <Col className="col-auto position-relative">
+                <Button onClick={this.handleCopyClick} className="radius-right-5 ml-2">
+                  <span>Copy</span>
+                  <FontAwesomeIcon className="ml-2" icon={faCopy} />
+                </Button>
+              </Col>
+            </Row>
+          </Form>
+        </ModalBody>
+      </Modal>
+    );
+  }
+}
+
+ModalRunOnMyOF.defaultProps = {
+  fn: {},
+};
+
+export {
+  ModalRunOnMyOF
+};

--- a/dashboard/client/src/components/ModalRunOnMyOF/index.js
+++ b/dashboard/client/src/components/ModalRunOnMyOF/index.js
@@ -1,0 +1,1 @@
+export * from './ModalRunOnMyOF'

--- a/dashboard/client/src/pages/FunctionDetailPage.jsx
+++ b/dashboard/client/src/pages/FunctionDetailPage.jsx
@@ -6,6 +6,7 @@ import { Card, CardHeader, CardBody } from 'reactstrap';
 import { functionsApi } from '../api/functionsApi';
 import { FunctionDetailSummary } from '../components/FunctionDetailSummary';
 import { GetBadgeModal } from '../components/GetBadgeModal'
+import { ModalRunOnMyOF } from '../components/ModalRunOnMyOF'
 
 export class FunctionDetailPage extends Component {
   constructor(props) {
@@ -16,6 +17,9 @@ export class FunctionDetailPage extends Component {
     this.handleShowBadgeModal = this.handleShowBadgeModal.bind(this);
     this.handleCloseBadgeModal = this.handleCloseBadgeModal.bind(this);
 
+    this.handleShowRunOnMyOFModal = this.handleShowRunOnMyOFModal.bind(this);
+    this.handleCloseRunOnMyOFModal = this.handleCloseRunOnMyOFModal.bind(this);
+
     this.state = {
       isLoading: true,
       fn: null,
@@ -23,6 +27,7 @@ export class FunctionDetailPage extends Component {
       repoPath,
       functionName,
       showBadgeModal: false,
+      showRunOnMyOFModal: false,
     };
   }
 
@@ -44,12 +49,21 @@ export class FunctionDetailPage extends Component {
     this.setState({ showBadgeModal: false });
   }
 
+  handleShowRunOnMyOFModal() {
+    this.setState({ showRunOnMyOFModal: true });
+  }
+
+  handleCloseRunOnMyOFModal() {
+    this.setState({ showRunOnMyOFModal: false });
+  }
+
   render() {
     const { isLoading, fn } = this.state;
     let panelBody = (
       <FunctionDetailSummary
         fn={fn}
         handleShowBadgeModal={this.handleShowBadgeModal}
+        handleShowRunOnMyOFModal={this.handleShowRunOnMyOFModal}
       />
     );
     
@@ -74,6 +88,7 @@ export class FunctionDetailPage extends Component {
           { panelBody }
         </CardBody>
         <GetBadgeModal state={this.state.showBadgeModal} closeModal={this.handleCloseBadgeModal} />
+        <ModalRunOnMyOF fn={fn || {}} state={this.state.showRunOnMyOFModal} closeModal={this.handleCloseRunOnMyOFModal} />
       </Card>
     );
   }

--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -9,7 +9,7 @@ functions:
   system-dashboard:
     lang: node8-express
     handler: ./of-cloud-dashboard
-    image: functions/of-cloud-dashboard:0.2.1
+    image: functions/of-cloud-dashboard:0.2.2
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Closes https://github.com/openfaas/openfaas-cloud/issues/171

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
- In function description page added button which clicked
opens modal with code which you need to run to quickly run
function in your OpenFaaS instance

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed on my own cluster end went to multiple different function pages checking if generated code is correct

## How are existing users impacted? What migration steps/scripts do we need?
This is just ui change, and doesn't need to any migration from user. It should just work  


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
