### PR TITLE
Add RepoURL and OwnerID to sdk

### DIFF
--- a/sdk/event.go
+++ b/sdk/event.go
@@ -13,6 +13,8 @@ type Event struct {
 	Secrets        []string          `json:"secrets"`
 	Private        bool              `json:"private"`
 	SCM            string            `json:"scm"`
+	RepoURL        string            `json:"repourl"`
+	OwnerID        int               `json:"owner-id"`
 }
 
 // BuildEventFromPushEvent function to build Event from PushEvent


### PR DESCRIPTION
Adding RepoURL and Owner ID in the SDK because it was
manually added in functions and not through vendoring

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

PR adds fields RepoURL and OwnerID which were missed in PRs [repoURL](https://github.com/openfaas/openfaas-cloud/commit/94f26bc7c89de29ceddf1cf0f9992def445bbd50) and [ownerID](https://github.com/openfaas/openfaas-cloud/commit/320c940501d868c471f1c74efca5995203e57255)
 to be released and re-vendored in the code where it is needed currently `buildshiprun`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A. addings to SDK

## How are existing users impacted? What migration steps/scripts do we need?

N.A.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
