### PR TITLE
Bump version of git-tar and buildshiprun 0.9.1

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -45,7 +45,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.9.0
+    image: functions/of-git-tar:0.9.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -66,7 +66,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: functions/of-buildshiprun:0.9.0
+    image: functions/of-buildshiprun:0.9.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
GitLab integration changed buildshiprun and git-tar
but I forgot to bump the versions of the functions

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Version bump of `git-tar` and `buildshiprun` 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

They have access to GitLab image

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
