### PR TITLE
Add annotations to list-functions

### DIFF
--- a/list-functions/handler.go
+++ b/list-functions/handler.go
@@ -86,4 +86,5 @@ type function struct {
 	InvocationCount float64           `json:"invocationCount"`
 	Replicas        uint64            `json:"replicas"`
 	Labels          map[string]string `json:"labels"`
+	Annotations     map[string]string `json:"annotations"`
 }


### PR DESCRIPTION
Annotation support for functions was added in previous
commits to the dashboard and buildshiprun but was forgotten
for list-functions and this change now enables it

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Small fix so list-functions now appends annotations so the actual annotation returned from the function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In end to end test on kubernetes instance

## How are existing users impacted? What migration steps/scripts do we need?

They will be able to see their URLs depending on whether or not they have GitLab or GitHub Cloud instances

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
