### PR TITLE
Add documentation fix on minio

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -355,14 +355,33 @@ kubectl create secret generic -n openfaas-fn \
 Install Minio with helm
 
 ```
-helm install --name cloud --namespace openfaas \
+helm install --name cloud-minio --namespace openfaas \
    --set accessKey=$ACCESS_KEY,secretKey=$SECRET_KEY,replicas=1,persistence.enabled=false,service.port=9000,service.type=NodePort \
   stable/minio
 ```
 
-The name value should be `cloud-minio.openfaas.svc.cluster.local`
+The value of the `--name` flag should be the name of the service we want to create and in our case the name is `cloud-minio`
 
-Enter the value of the DNS above into `s3_url` in `gateway_config.yml` adding the port at the end:`cloud-minio-svc.openfaas.svc.cluster.local:9000`
+The URL is formatted like so:
+
+```
+<service_name>.<namespace>.svc.cluster.local:<port>
+```
+
+and in our case minio can be accessed with this URL: 
+
+```
+cloud-minio.openfaas.svc.cluster.local:9000
+```
+
+
+Enter the value of the DNS above into `s3_url` in `gateway_config.yml` adding the port at the end:
+
+```
+  s3_url: cloud-minio.openfaas.svc.cluster.local:9000
+```
+
+> Note: minio uses port 9000
 
 #### Swarm
 


### PR DESCRIPTION
Fixing details around minio set up because the documentation
was little big confusing and incorrect.

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

The part of the documentation which describes how to set up minio had some misleading information for example `name` attribute was saying that it should be set to the DNS where minio could be accessed from inside the cluster

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

Easier set up for minio in case you have no idea how services, namespaces etc. work on creating DNS to access service

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
