### PR TITLE
Make the customer the owner of the repo

### DIFF
--- a/gitlab-event/handler.go
+++ b/gitlab-event/handler.go
@@ -94,13 +94,18 @@ func Handle(req []byte) string {
 			return fmt.Sprintf("unable to unmarshal request into eventInfo struct: %s", unmarshalErr.Error())
 		}
 
+		username, usernameErr := getUser(eventInfo.GitLabProject.PathWithNamespace)
+		if usernameErr != nil {
+			return fmt.Sprintf("error while formatting username: %s", usernameErr.Error())
+		}
+
 		if readBool("validate_customers") {
 			customersURL := os.Getenv("customers_url")
 			customers, getErr := getCustomers(customersURL)
 			if getErr != nil {
 				return fmt.Sprintf("unable to read customers from %s error: %s", customersURL, getErr.Error())
 			}
-			if !validCustomer(customers, eventInfo.UserUsername) {
+			if !validCustomer(customers, username) {
 				auditEvent := sdk.AuditEvent{
 					Message: "Customer not found",
 					Owner:   eventInfo.UserUsername,

--- a/gitlab.yml
+++ b/gitlab.yml
@@ -6,7 +6,7 @@ functions:
   system-gitlab-event:
     lang: go
     handler: ./gitlab-event
-    image: functions/gitlab-event:0.1.0
+    image: functions/gitlab-event:0.1.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Making the customer the owner of the repo rather than
the user who was the source of the commit.

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

I though when pushing the customer should be the person responsible for pushing the commit, but the customer in reality is the person who owns the repository. This PR references that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Live environment

## How are existing users impacted? What migration steps/scripts do we need?

People will be able to add changes to repositories, by only adding the owner of the repository to CUSTOMERS

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
