### PR TITLE
Show functions from organizations

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -19,7 +19,7 @@ The Dashboard is a SPA(Single Page App) made with React and will require the fol
 This may be simpler than deploying the builder and connecting your OpenFaaS Cloud to a GitHub App.
 
 ```
-$ faas-cli store deploy figlet --name alexellis-figlet --label Git-Owner=alexellis \
+$ faas-cli store deploy figlet --name alexellis-figlet --label com.openfaas.cloud.git-owner=alexellis \
  --label com.openfaas.cloud.git-repo=figlet \
  --label com.openfaas.cloud.git-sha=665d9597547d8e0425630ba2dbb73c2951a61ce2 \
  --label com.openfaas.cloud.git-deploytime=1533026741 \

--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -16,6 +16,7 @@
     window.PUBLIC_URL = '__PUBLIC_URL__';
     window.PRETTY_URL = '__PRETTY_URL__';
     window.QUERY_PRETTY_URL = '__QUERY_PRETTY_URL__';
+    window.ORGANIZATIONS = '__ORGANIZATIONS__';
   </script>
 </head>
 

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -93,7 +93,23 @@ class FunctionsApi {
       };
     });
   }
-  fetchFunctions(user) {
+
+  fetchFunctions(user, organizations) {
+    var orgs = [];
+    orgs.push(user);
+    if (organizations) {
+      orgs = orgs.concat(organizations.split(',')).filter(item => item);
+    }
+
+    var fetchPromises = [];
+    orgs.forEach((org)=> {
+      fetchPromises.push(this.fetchFunctionsByUser(org));
+    });
+
+    return Promise.all(fetchPromises);
+  }
+
+  fetchFunctionsByUser(user) {
     const url = `${this.apiBaseUrl}/list-functions?user=${user}`;
     return axios
       .get(url)

--- a/dashboard/client/src/pages/FunctionsOverviewPage.jsx
+++ b/dashboard/client/src/pages/FunctionsOverviewPage.jsx
@@ -18,8 +18,20 @@ export class FunctionsOverviewPage extends Component {
   componentDidMount() {
     this.setState({ isLoading: true });
 
-    functionsApi.fetchFunctions(this.state.user).then(res => {
-      this.setState({ isLoading: false, fns: res });
+
+    functionsApi.fetchFunctions(this.state.user, window.ORGANIZATIONS)
+    .then(res => {
+      let functions = [];
+      res.forEach( (set) => {
+        set.forEach(  (item) => {
+          functions.push(item);
+        });
+      });
+
+      this.setState({ isLoading: false, fns: functions });
+    })
+    .catch((e) => {
+      console.error(e);
     });
   }
 


### PR DESCRIPTION
## Description

With this change users will be able not only to see functions they
own, but also the ones that belong to the organizations they are
members of

Closes 1. and 2. from #347 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed the dashboard + list-functions on a cluster.
Tested with `docwareiy/of-cloud-dashboard:0.3.1-list-orgs-fn`
After setting a cookie of type `openfaas_cloud_token=<jwt with organizations>` the listed functions were functions from the user + functions from orgs.

After deleting the cookie, listed functions were only functions from user.

Tested with OAuth it's listing functions from both user and orgs, sorting the user first.

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required) N/A
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests