### PR TITLE
Fixed styling of function invocation metrics

### DIFF
--- a/dashboard/client/src/components/FunctionInvocation/index.jsx
+++ b/dashboard/client/src/components/FunctionInvocation/index.jsx
@@ -55,20 +55,20 @@ export class FunctionInvocation extends React.Component {
           </Progress>
           <span className="font-weight-bold">{total}</span> invocations
         </div>
-        <ListGroup className="mt-3 m0 flex-row">
-          <ListGroupItem className="d-flex flex-fill flex-column align-items-center">
-            <h5 className="m-0">
+        <div className="mt-3 mx-1 row flex-row border">
+          <div className="d-flex col-6 flex-column align-items-center border-right p-2">
+            <h5 className="mt-1">
               <Badge color="success">{success}</Badge>
             </h5>
             <span>Success</span>
-          </ListGroupItem>
-          <ListGroupItem className="d-flex flex-fill flex-column align-items-center">
-            <h5 className="m0">
+          </div>
+          <div className="d-flex col-6 flex-column align-items-center p-2">
+            <h5 className="mt-1">
               <Badge color="danger">{failure}</Badge>
             </h5>
             <span>Error</span>
-          </ListGroupItem>
-        </ListGroup>
+          </div>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
This resolves the styling issue with displaying function invocation metrics.

Signed-off-by: jagreehal <jag.reehal@gmail.com>

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
