### PR TITLE
Add user/org filtering to dashboard

### DIFF
--- a/dashboard/client/src/components/FunctionTable/FunctionTable.jsx
+++ b/dashboard/client/src/components/FunctionTable/FunctionTable.jsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Table } from 'reactstrap';
+import { Table, UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
 
 import { withRouter } from 'react-router-dom';
 
-import { FunctionTableItem } from '../FunctionTableItem';
+import { FunctionTableItem, genOwnerInitials } from '../FunctionTableItem';
 
 import './FunctionTable.css'
 
-function renderBody(fns, user, clickHandler) {
+function renderBody(fns, user, clickHandler, filter) {
   if (fns.length === 0) {
     return (
       <tr>
@@ -17,56 +17,133 @@ function renderBody(fns, user, clickHandler) {
       </tr>
     );
   } else {
-    return fns.map((fn) => {
+    return fns.filter(({ gitOwner }) => filter(gitOwner)).map((fn) => {
+
       return (
-        <FunctionTableItem key={fn.shortSha} fn={fn} user={user} onClick={clickHandler} />
+        <FunctionTableItem key={fn.shortSha + fn.name} fn={fn} user={user} onClick={clickHandler} />
       );
     });
   }
 }
 
-const FunctionTable = withRouter(({ isLoading, fns, user, history }) => {
-  const onRowClick = to => history.push(to);
-  const tbody = isLoading ? (
-    <tr>
-      <td colSpan="8" style={{ textAlign: 'center' }}>
-        <FontAwesomeIcon icon="spinner" spin />
-      </td>
-    </tr>
-  ) : (
-    renderBody(fns, user, onRowClick)
-  );
+class FunctionTableWithoutRouter extends Component {
+  constructor(props) {
+    super(props);
 
-  let tableProps = {
-    responsive: true,
-    className: 'function-table',
-  };
+    this.state = {
+      filter: localStorage.getItem('filter') || '',
+    };
 
-  if (fns && fns.length > 0) {
-    tableProps.hover = true;
+    this.saveFilter = this.saveFilter.bind(this);
+    this.handleOwnerClick = this.handleOwnerClick.bind(this);
+    this.clearFilter = this.clearFilter.bind(this);
+    this.renderOwnersElems = this.renderOwnersElems.bind(this);
   }
 
-  return (
-    <Table {...tableProps}>
-      <thead>
+  saveFilter(filter) {
+    this.setState({ filter });
+
+    localStorage.setItem('filter', filter);
+  }
+
+  handleOwnerClick(owner) {
+    this.saveFilter(owner);
+  }
+
+  clearFilter() {
+    this.saveFilter('');
+  }
+
+  renderOwnersElems(fns) {
+    const { filter } = this.state;
+
+    const owners = fns.reduce((acc, { gitOwner }) => {
+      if (acc.includes(gitOwner)) {
+        return acc;
+      }
+
+      return [...acc, gitOwner];
+    }, []);
+
+    const elems = owners.map(owner => (
+      <DropdownItem
+        tag="a"
+        onClick={() => this.handleOwnerClick(owner)}
+        key={owner}
+        active={filter === owner}
+      >
+        { `(${genOwnerInitials(owner).toUpperCase()}) ${owner}` }
+      </DropdownItem>
+    ));
+
+    if (filter !== '') {
+      elems.push(<DropdownItem key="divider" divider />);
+      elems.push((
+        <DropdownItem key="clear" onClick={this.clearFilter}>
+          Clear
+        </DropdownItem>
+      ));
+    }
+
+    return elems;
+  }
+
+  render() {
+    const { isLoading, fns, user, history } = this.props;
+    const onRowClick = to => history.push(to);
+
+    let tableProps = {
+      responsive: true,
+      className: 'function-table',
+    };
+
+    if (fns && fns.length > 0) {
+      tableProps.hover = true;
+    }
+
+    const tbody = isLoading ? (
       <tr>
-        <th>Owner</th>
-        <th>Name</th>
-        <th style={{ width: '42px' }} />
-        <th>Repository</th>
-        <th>SHA</th>
-        <th>Deployed</th>
-        <th>Invocations</th>
-        <th>Replicas</th>
-        <th />
+        <td colSpan="8" class="text-center">
+          <FontAwesomeIcon icon="spinner" spin />
+        </td>
       </tr>
-      </thead>
-      <tbody id="items">
-        { tbody }
-      </tbody>
-    </Table>
-  );
-});
+    ) : (
+      renderBody(fns, user, onRowClick, item => this.state.filter === '' || this.state.filter === item)
+    );
+
+    return (
+      <Table {...tableProps}>
+        <thead>
+        <tr>
+          <th>
+            <UncontrolledDropdown setActiveFromChild>
+              <DropdownToggle tag="a" caret>
+                Owner
+              </DropdownToggle>
+              <DropdownMenu>
+                { this.renderOwnersElems(fns) }
+              </DropdownMenu>
+            </UncontrolledDropdown>
+          </th>
+          <th>Name</th>
+          <th style={{ width: '42px' }} />
+          <th>Repository</th>
+          <th>SHA</th>
+          <th>Deployed</th>
+          <th>Invocations</th>
+          <th>Replicas</th>
+          <th />
+        </tr>
+        </thead>
+        <tbody id="items">
+          { tbody }
+        </tbody>
+      </Table>
+    );
+  }
+}
+
+const FunctionTable = withRouter(FunctionTableWithoutRouter);
 
 FunctionTable.propTypes = {
   isLoading: PropTypes.bool.isRequired,

--- a/dashboard/client/src/components/FunctionTable/FunctionTable.jsx
+++ b/dashboard/client/src/components/FunctionTable/FunctionTable.jsx
@@ -50,6 +50,7 @@ const FunctionTable = withRouter(({ isLoading, fns, user, history }) => {
     <Table {...tableProps}>
       <thead>
       <tr>
+        <th>Owner</th>
         <th>Name</th>
         <th style={{ width: '42px' }} />
         <th>Repository</th>

--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -17,12 +17,70 @@ const genRepoUrl = ({ gitOwner, gitRepoURL }) => (
   `${gitRepoURL}/commits/master`
 );
 
-const genOwner = ({ gitOwner }) => (
-  (gitOwner.split(/[-_]+/).length > 1) ?
-    gitOwner.split(/[-_]+/)[0].substring(0, 1).concat(gitOwner.split(/[-_]+/)[1].substring(0, 1)) :
-      gitOwner.split(/[-_]+/)[0].substring(0, 2)
+const genOwnerInitials = (owner) => (
+  (owner.split(/[-_]+/).length > 1) ?
+    owner.split(/[-_]+/)[0].substring(0, 1).concat(owner.split(/[-_]+/)[1].substring(0, 1)) :
+      owner.split(/[-_]+/)[0].substring(0, 2)
 
 );
+
+// For detailed explanation on what is the method bellow doing, please check
+// https://stackoverflow.com/questions/3426404/create-a-hexadecimal-colour-based-on-a-string-with-javascript
+const stringToColour = (str) => {
+  const hash = [...str].reduce((acc, curr) => curr.charCodeAt(0) + ((acc << 5) - acc), 0);
+
+  let colour = '#';
+
+  for (let i = 0; i < 3; i++) {
+    const value = (hash >> (i * 8)) & 0xFF;
+
+    colour += ('00' + value.toString(16)).substr(-2);
+  }
+
+  return colour;
+};
+
+const padZero = (str, len) => {
+  len = len || 2;
+
+  const zeros = new Array(len).join('0');
+
+  return (zeros + str).slice(-len);
+};
+
+function invertColor(hex, blackAndWhite) {
+  if (hex.indexOf('#') === 0) {
+    hex = hex.slice(1);
+  }
+
+  // convert 3-digit hex to 6-digits.
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+
+  if (hex.length !== 6) {
+    throw new Error('Invalid HEX color.');
+  }
+
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+
+  if (blackAndWhite) {
+    // http://stackoverflow.com/a/3943023/112731
+    return (r * 0.299 + g * 0.587 + b * 0.114) > 186
+      ? '#000000'
+      : '#ffffff';
+  }
+
+  // invert color components
+  const rs = (255 - r).toString(16);
+  const gs = (255 - g).toString(16);
+  const bs = (255 - b).toString(16);
+
+  // pad each with zeros and return
+  return "#" + padZero(rs) + padZero(gs) + padZero(bs);
+}
 
 const FunctionTableItem = ({ onClick, fn, user }) => {
   const {
@@ -38,14 +96,24 @@ const FunctionTableItem = ({ onClick, fn, user }) => {
   const repoUrl = genRepoUrl(fn);
   const logPath = genLogPath(fn, user);
   const fnDetailPath = genFnDetailPath(fn, user);
-  const owner = genOwner(fn);
+  const owner = genOwnerInitials(fn.gitOwner);
 
   const handleClick = () => onClick(fnDetailPath);
+
+  const ownerColor = stringToColour(fn.gitOwner);
 
   return (
     <tr onClick={handleClick} className="cursor-pointer">
       <td>
-        <div class="rounded border border-secondary w-50 text-center">
+        <div
+          className="rounded w-50 text-center text-uppercase"
+          title={fn.gitOwner}
+          style={{
+            backgroundColor: ownerColor,
+            color: invertColor(ownerColor, true),
+            fontWeight: 700,
+          }}
+        >
           { owner }
         </div>
       </td>
@@ -96,5 +164,6 @@ const FunctionTableItem = ({ onClick, fn, user }) => {
 };
 
 export {
-  FunctionTableItem
+  FunctionTableItem,
+  genOwnerInitials,
 };

--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -17,6 +17,13 @@ const genRepoUrl = ({ gitOwner, gitRepoURL }) => (
   `${gitRepoURL}/commits/master`
 );
 
+const genOwner = ({ gitOwner }) => (
+  (gitOwner.split(/[-_]+/).length > 1) ?
+    gitOwner.split(/[-_]+/)[0].substring(0, 1).concat(gitOwner.split(/[-_]+/)[1].substring(0, 1)) :
+      gitOwner.split(/[-_]+/)[0].substring(0, 2)
+
+);
+
 const FunctionTableItem = ({ onClick, fn, user }) => {
   const {
     shortName,
@@ -31,11 +38,17 @@ const FunctionTableItem = ({ onClick, fn, user }) => {
   const repoUrl = genRepoUrl(fn);
   const logPath = genLogPath(fn, user);
   const fnDetailPath = genFnDetailPath(fn, user);
+  const owner = genOwner(fn);
 
   const handleClick = () => onClick(fnDetailPath);
 
   return (
     <tr onClick={handleClick} className="cursor-pointer">
+      <td>
+        <div class="rounded border border-secondary w-50 text-center">
+          { owner }
+        </div>
+      </td>
       <td>{shortName}</td>
       <td>
         <Button


### PR DESCRIPTION
After listing functions both from the user and the organizations
they are part of, function owner should be available in the UI in
order to indicate if the function is owned by orgs or by user

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Added owner filtering to function table

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

Closes #359 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<img width="1183" alt="screen shot 2018-12-11 at 22 36 01" src="https://user-images.githubusercontent.com/4160133/49829429-13455500-fd97-11e8-948d-bc7fa2d27fe8.png">

with `docwareiy/of-cloud-dashboard:0.3.4-show-owner`

Latest change: (the colors are from following PR by @bartsmykla based on this)
<img width="1178" alt="screen shot 2018-12-14 at 10 10 21" src="https://user-images.githubusercontent.com/4160133/49991081-9083ec00-ff88-11e8-835f-3488459a49be.png">

Dashboard: https://system.smykla.io/dashboard/bartsmykla

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required) N/A
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A