### PR TITLE
Moved creation of http client outside of sendReport

### DIFF
--- a/gitlab-status/handler.go
+++ b/gitlab-status/handler.go
@@ -88,8 +88,8 @@ func sendReport(URL string, token string, state string, desc string, context str
 		return fmt.Errorf("error while creating request to GitLab API: %s", reqErr.Error())
 	}
 	req.Header.Set("PRIVATE-TOKEN", token)
-	client := &http.Client{}
-	resp, clientErr := client.Do(req)
+
+	resp, clientErr := http.DefaultClient.Do(req)
 	if clientErr != nil {
 		return fmt.Errorf("error while sending request to GitLab API: %s", clientErr.Error())
 	}


### PR DESCRIPTION
Closes https://github.com/openfaas/openfaas-cloud/issues/354

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description
http.Client is created in root scope, so it's not recreated
every time, when sendReport is being invoked.

## How Has This Been Tested?
Deployed to my cluster on AWS.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
They shouldn't be because the result should be the same, just performance should be improved.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
