### PR TITLE
Moving dashboard env vars into environment_file

### DIFF
--- a/dashboard/dashboard_config.yml
+++ b/dashboard/dashboard_config.yml
@@ -1,0 +1,12 @@
+environment:
+  write_debug: true
+  # gateway_url: http://gateway:8080/ # when using Swarm
+  gateway_url: http://gateway.openfaas:8080/
+  # base_href: `/function/system-dashboard/` # if not using router
+  base_href: '/dashboard/'
+  # public_url: http://laptop-ip:8080/ # use IP of laptop or remote machine, do not use localhost/127.0.0.1
+  public_url: https://system.o6s.io
+  # Comment out if not using public pretty-URL
+  pretty_url: https://user.o6s.io/function
+  # Comment out if not using public pretty-URL
+  query_pretty_url: 'true'

--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -10,18 +10,8 @@ functions:
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
-    environment:
-      write_debug: true
-      # gateway_url: http://gateway:8080/ # when using Swarm
-      gateway_url: http://gateway.openfaas:8080/
-      # base_href: `/function/system-dashboard/` # if not using router
-      base_href: '/dashboard/'
-      # public_url: http://laptop-ip:8080/ # use IP of laptop or remote machine, do not use localhost/127.0.0.1
-      public_url: https://system.o6s.io
-      # Comment out if not using public pretty-URL
-      pretty_url: https://user.o6s.io/function
-      # Comment out if not using public pretty-URL
-      query_pretty_url: 'true'
+    environment_file:
+      - dashboard_config.yml
 
   system-list-functions:
     skip_build: true


### PR DESCRIPTION
This is in preparation for bootstrap project.

## How Has This Been Tested?
Tested with ofc-bootstrap + kind setup


## How are existing users impacted? What migration steps/scripts do we need?
There should be no impact.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
