### PR TITLE
Add the URL builders to SDK

### DIFF
--- a/sdk/url_builders.go
+++ b/sdk/url_builders.go
@@ -1,0 +1,76 @@
+package sdk
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	SystemSubdomain = "system"
+)
+
+// FormatEndpointURL takes the gateway_public_url environmental
+// variable along with event object to format URL which points to
+// the function endpoint
+func FormatEndpointURL(gatewayURL string, event *Event) (string, error) {
+	systemURL, formatErr := FormatSystemURL(gatewayURL)
+	if formatErr != nil {
+		return "", fmt.Errorf("error while formattig endpoint URL: %s", formatErr.Error())
+	}
+	personalURL := strings.Replace(systemURL, SystemSubdomain, event.Owner, -1)
+
+	return fmt.Sprintf("%s/%s", personalURL, event.Service), nil
+}
+
+// FormatDashboardURL takes the environmental variable
+// gateway_public_url and event object and formats
+// the URL to point to the dashboard
+func FormatDashboardURL(gatewayURL string, event *Event) (string, error) {
+	systemURL, formatErr := FormatSystemURL(gatewayURL)
+	if formatErr != nil {
+		return "", fmt.Errorf("error while formatting dashboard URL: %s", formatErr.Error())
+	}
+
+	return fmt.Sprintf("%s/dashboard/%s", systemURL, event.Owner), nil
+}
+
+// GetSubdomain gets the subdomain of the URL
+// for example the subdomain of www.o6s.io
+// would be www
+func GetSubdomain(URL string) (string, error) {
+	parsedURL, parseErr := url.Parse(URL)
+	if parseErr != nil {
+		return "", fmt.Errorf("Unable to parse URL: %s", parseErr.Error())
+	}
+	subdomain := strings.Split(parsedURL.Host, ".")
+
+	//Host is www.world.org and subdomain would be www aka. 0th element of the slice
+	return subdomain[0], nil
+}
+
+// FormatSystemURL formats the system URL which points to the
+// of-router with the gateway_public_url environmental variable
+func FormatSystemURL(gatewayURL string) (string, error) {
+	if strings.HasSuffix(gatewayURL, "/") {
+		gatewayURL = strings.TrimSuffix(gatewayURL, "/")
+	}
+	subdomain, err := GetSubdomain(gatewayURL)
+	if err != nil {
+		return "", fmt.Errorf("error while geting subdomain for system URL: %s", err)
+	}
+	systemURL := strings.Replace(gatewayURL, subdomain, SystemSubdomain, -1)
+	return systemURL, nil
+}
+
+// FormatLogsURL formats the URL where function logs are stored with
+// the gateway_public_url environmental variable and event object
+func FormatLogsURL(gatewayURL string, event *Event) (string, error) {
+	systemURL, formatErr := FormatSystemURL(gatewayURL)
+	if formatErr != nil {
+		return "", fmt.Errorf("error while formatting logs URL: %s", formatErr.Error())
+	}
+
+	return fmt.Sprintf("%s/dashboard/%s/%s/log?repoPath=%s/%s&commitSHA=%s",
+		systemURL, event.Owner, event.Service, event.Owner, event.Repository, event.SHA), nil
+}

--- a/sdk/url_builders_test.go
+++ b/sdk/url_builders_test.go
@@ -1,0 +1,216 @@
+package sdk
+
+import (
+	"testing"
+)
+
+func Test_GetSubdomain(t *testing.T) {
+	tests := []struct {
+		title             string
+		URL               string
+		expectedErr       error
+		expectedSubdomain string
+	}{
+		{
+			title:             "URL is with the right format",
+			URL:               "https://www.organization.org",
+			expectedErr:       nil,
+			expectedSubdomain: "www",
+		},
+		{
+			title:             "URL has only host",
+			URL:               "www.organization.org",
+			expectedErr:       nil,
+			expectedSubdomain: "",
+		},
+		{
+			title:             "URL is not set",
+			URL:               "",
+			expectedErr:       nil,
+			expectedSubdomain: "",
+		},
+	}
+	for _, test := range tests {
+		Subdomain, domainErr := GetSubdomain(test.URL)
+		if domainErr != test.expectedErr {
+			t.Errorf("expected error: %v got: %v", test.expectedErr, domainErr)
+		}
+		if Subdomain != test.expectedSubdomain {
+			t.Errorf("Expected URL: %s got: %s", test.expectedSubdomain, Subdomain)
+		}
+	}
+}
+
+func Test_FormatSystemURL(t *testing.T) {
+	tests := []struct {
+		title       string
+		gatewayURL  string
+		expectedURL string
+	}{
+		{
+			title:       "\"gateway_public_url\" environmental variable is set with trailing slash",
+			gatewayURL:  "https://cloud.o6s.io/",
+			expectedURL: "https://system.o6s.io",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is set without trailing slash",
+			gatewayURL:  "https://cloud.o6s.io",
+			expectedURL: "https://system.o6s.io",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is unset",
+			gatewayURL:  "",
+			expectedURL: "system",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			systemURL, _ := FormatSystemURL(test.gatewayURL)
+			if systemURL != test.expectedURL {
+				t.Errorf("Expected URL: %s got: %s", test.expectedURL, systemURL)
+			}
+		})
+	}
+}
+
+func Test_FormatDashboardURL(t *testing.T) {
+	tests := []struct {
+		title       string
+		event       *Event
+		gatewayURL  string
+		expectedURL string
+	}{
+		{
+			title: "\"gateway_public_url\" environmental variable is set and Event object is set",
+			event: &Event{
+				Owner: "user",
+			},
+			gatewayURL:  "https://cloud.o6s.io/",
+			expectedURL: "https://system.o6s.io/dashboard/user",
+		},
+		{
+			title: "\"gateway_public_url\" environmental variable is unset and Event object is set",
+			event: &Event{
+				Owner: "user",
+			},
+			gatewayURL:  "",
+			expectedURL: "system/dashboard/user",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is unset and Event object is empty",
+			event:       &Event{},
+			gatewayURL:  "",
+			expectedURL: "system/dashboard/",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			dashboardURL, _ := FormatDashboardURL(test.gatewayURL, test.event)
+			if dashboardURL != test.expectedURL {
+				t.Errorf("Expected URL: %s got: %s", test.expectedURL, dashboardURL)
+			}
+		})
+	}
+}
+
+func Test_FormatEndpointURL(t *testing.T) {
+	tests := []struct {
+		title       string
+		event       *Event
+		gatewayURL  string
+		expectedURL string
+	}{
+		{
+			title: "\"gateway_public_url\" environmental variable is set and Event object is set",
+			event: &Event{
+				Service: "cloud-func",
+				Owner:   "user",
+			},
+			gatewayURL:  "https://cloud.o6s.io/",
+			expectedURL: "https://user.o6s.io/cloud-func",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is set but Event object is empty",
+			event:       &Event{},
+			gatewayURL:  "https://cloud.o6s.io",
+			expectedURL: "https://.o6s.io/",
+		},
+		{
+			title: "\"gateway_public_url\" environmental variable is unset but Event object is set",
+			event: &Event{
+				Service: "cloud-func",
+				Owner:   "user",
+			},
+			gatewayURL:  "",
+			expectedURL: "user/cloud-func",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is empty and Event object is empty",
+			event:       &Event{},
+			gatewayURL:  "",
+			expectedURL: "/",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			endpointURL, _ := FormatEndpointURL(test.gatewayURL, test.event)
+			if endpointURL != test.expectedURL {
+				t.Errorf("Expected URL: %s got: %s", test.expectedURL, endpointURL)
+			}
+		})
+	}
+}
+func Test_FormatLogsURL(t *testing.T) {
+	tests := []struct {
+		title       string
+		event       *Event
+		gatewayURL  string
+		expectedURL string
+	}{
+		{
+			title: "\"gateway_public_url\" environmental variable is configured and Event object is populated",
+			event: &Event{
+				Owner:      "user",
+				Service:    "cloud-func",
+				Repository: "cloud-func-repo",
+				SHA:        "98zxc823axcc",
+			},
+			gatewayURL:  "https://cloud.o6s.io/",
+			expectedURL: "https://system.o6s.io/dashboard/user/cloud-func/log?repoPath=user/cloud-func-repo&commitSHA=98zxc823axcc",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is configured but the Event object is not populated",
+			event:       &Event{},
+			gatewayURL:  "https://cloud.o6s.io/",
+			expectedURL: "https://system.o6s.io/dashboard///log?repoPath=/&commitSHA=",
+		},
+		{
+			title: "\"gateway_public_url\" environmental variable is empty but the Event object is populated",
+			event: &Event{
+				Owner:      "user",
+				Service:    "cloud-func",
+				Repository: "cloud-func-repo",
+				SHA:        "98zxc823axcc",
+			},
+			gatewayURL:  "",
+			expectedURL: "system/dashboard/user/cloud-func/log?repoPath=user/cloud-func-repo&commitSHA=98zxc823axcc",
+		},
+		{
+			title:       "\"gateway_public_url\" environmental variable is empty and Event object is not populated right",
+			event:       &Event{},
+			gatewayURL:  "",
+			expectedURL: "system/dashboard///log?repoPath=/&commitSHA=",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			logsURL, _ := FormatLogsURL(test.gatewayURL, test.event)
+			if logsURL != test.expectedURL {
+				t.Errorf("expected URL: %s got: %s", test.expectedURL, logsURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding the URL builders to SDK in seperate PR to
vendor them in the PR #323 once this commit
is merged/released

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description
The PR is needed so the SDK is merged and released to and vendored in PR #323 and #330 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A. Added unit tests and tested the functions in PR #323

## How are existing users impacted? What migration steps/scripts do we need?

N.A. - this predates #323 and #330 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
