### PR TITLE
Add liveness probes to deployments

### DIFF
--- a/yaml/core/of-auth-dep.yml
+++ b/yaml/core/of-auth-dep.yml
@@ -26,6 +26,13 @@ spec:
       - name: of-auth
         image: openfaas/cloud-auth:0.5.0
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
         env:
           - name: port
             value: "8080"

--- a/yaml/core/of-builder-dep.yml
+++ b/yaml/core/of-builder-dep.yml
@@ -23,6 +23,13 @@ spec:
       - name: of-builder
         image: openfaas/of-builder:0.6.2
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
         env:
           - name: enable_lchown
             value: "true"

--- a/yaml/core/of-router-dep.yml
+++ b/yaml/core/of-router-dep.yml
@@ -16,6 +16,13 @@ spec:
       - name: of-router
         image: openfaas/cloud-router:0.5.1
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 2
         env:
           - name: upstream_url
             value: "http://gateway.openfaas:8080"


### PR DESCRIPTION
Adding liveness probes to deployments
with default values

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

## Description

Adding liveness probes to deployments with default get to `/healthz` with initial get request starting after 3 seconds and on every 10 seconds perform that request to verify the container is healthy. Timeout of the request is set to two seconds.

Closes #378 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N.A.

## How are existing users impacted? What migration steps/scripts do we need?

N.A. redeploy the deployments in order to have the health check configured

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
