### PR TITLE
Update NetworkPolicy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -231,13 +231,6 @@ kubectl apply -f ./yaml/core
 kubectl apply -f ./yaml/network-policy
 ```
 
-(Optional) Add a role of "openfaas-system" using a label to the namespace where you deployed Ingress Controller. For example if Ingress Controller is deployed in the namespace `ingress-nginx`:
-```
-kubectl label namespace ingress-nginx role=openfaas-system
-```
-
-If you don't have Ingress Controller installed in cluster. [Read this](#troubleshoot-network-policies)
-
 #### For Swarm
 
 Create the secret for your registry
@@ -469,23 +462,12 @@ kubectl get events --sort-by=.metadata.creationTimestamp -n openfaas-fn
 ```
 
 ##### Troubleshoot Network Policies
-The NetworkPolicy configuration is designed to work with a Kubernetes IngressController. If you are using a NodePort or LoadBalancer you have to deploy NetworkPolicy below.
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: gateway
-  namespace: openfaas
-spec:
-  policyTypes:
-    - Ingress
-  podSelector:
-    matchLabels:
-      app: gateway
-  ingress:
-    - from: []
-      ports:
-        - port: 8080
+
+The NetworkPolicy configuration is designed to work with a namespaces `openfaas` and `openfaas-fn`.
+If your are using different namespaces you need to make sure that they're labeled correctly:
+```
+kubectl label ns openfaas role=openfaas-system
+kubectl label ns openfaas-fn role=openfaas-fn
 ```
 
 #### Troubleshoot Swarm

--- a/yaml/network-policy/ns-openfaas-net-policy.yml
+++ b/yaml/network-policy/ns-openfaas-net-policy.yml
@@ -8,7 +8,14 @@ spec:
     - Ingress
   podSelector: {}
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              role: openfaas-system
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          role: openfaas-system
+
+    - namespaceSelector:
+        matchLabels:
+          role: openfaas-fn
+      podSelector:
+        matchLabels:
+          role: openfaas-system


### PR DESCRIPTION
This issue need to be resolved before: https://github.com/openfaas/faas-netes/issues/367

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed OpenFaaS Cloud on new cluster created on 1 droplet (8GB RAM, 8CPU cores) with `calico` network plugin, then I applied network policies and tried to connect from:
- `openfaas-fn` namespace from functions with label `role=openfaas-system` to functions inside `openfaas` namespace
- from functions in `openfaas` namespace to functions in `openfaas` namespace
- from functions in `openfaas` namespace to functions in `openfaas-fn` namespace
- checked if all deployed functions work from the internet
- checked if dashboard is working

## How are existing users impacted? What migration steps/scripts do we need?
They shouldn't be if they are not using NetworkPolicies (they were not working correctly before, and nobody from the community reported any problems, so I assume that nobody was using it).

If somebody want to use NetworkPolicies now, there is only need to deploy it do the cluster using command:
```
kubectl apply -f ./yaml/network-policy
```



## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
