### PR TITLE
Add /healthz endpoint to router and of-builder

### DIFF
--- a/of-builder/main.go
+++ b/of-builder/main.go
@@ -61,6 +61,8 @@ func main() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/build", buildHandler)
+	router.HandleFunc("/healthz", healthzHandler)
+
 	server := &http.Server{
 		Addr:    "0.0.0.0:8080",
 		Handler: router,
@@ -310,4 +312,17 @@ func validateRequest(req *[]byte, r *http.Request) (err error) {
 	}
 
 	return nil
+}
+
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+
+	switch r.Method {
+	case http.MethodGet:
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+		break
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
 }

--- a/router/main.go
+++ b/router/main.go
@@ -42,6 +42,7 @@ func main() {
 
 	router := http.NewServeMux()
 	router.HandleFunc("/", makeHandler(c, cfg.Timeout, cfg.UpstreamURL, &authProxy1))
+	router.HandleFunc("/healthz", makeHealthzHandler())
 
 	log.Printf("Using port %s\n", cfg.Port)
 
@@ -260,4 +261,19 @@ func makeProxy(timeout time.Duration) *http.Client {
 		},
 	}
 	return &proxyClient
+}
+
+func makeHealthzHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+			break
+
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
 }


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

## Description
This changes adds `/healthz` endpoint to `router` and `of-builder`. 
Fixes: #381 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?



## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
