### PR TITLE
Add ARMHF/ARM64 build image support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,20 @@
 TAG?=latest
-
+.PHONY: all
 all:
 	cd contrib && ./ci.sh
+
+.PHONY: ci-armhf-build
+ci-armhf-build:
+	./contrib/ci-arm.sh "build"
+
+.PHONY: ci-armhf-push
+ci-armhf-push:
+	./contrib/ci-arm.sh "push"
+
+.PHONY: ci-arm64-build
+ci-arm64-build:
+	./contrib/ci-arm.sh "build"
+
+.PHONY: ci-arm64-push
+ci-arm64-push:
+	./contrib/ci-arm.sh "push"

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.10-alpine AS builder
-
+RUN apk add --no-cache g++
 WORKDIR /go/src/github.com/openfaas/openfaas-cloud/auth
 
 COPY vendor     vendor

--- a/auth/Makefile
+++ b/auth/Makefile
@@ -5,3 +5,15 @@ build:
 
 push:
 	docker push openfaas/cloud-auth:$(TAG)
+
+ci-armhf-build:
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/cloud-auth:$(TAG)-armhf .
+
+ci-armhf-push:
+	docker push openfaas/cloud-auth:$(TAG)-armhf
+
+ci-arm64-build:
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/cloud-auth:$(TAG)-arm64 .
+
+ci-arm64-push:
+	docker push openfaas/cloud-auth:$(TAG)-arm64

--- a/contrib/ci-arm.sh
+++ b/contrib/ci-arm.sh
@@ -2,6 +2,7 @@
 
 HERE=`pwd`
 ARCH=$(uname -m)
+ACTION=${1}
 declare -a folders=("of-builder" "router" "auth")
 
 if [ "$ARCH" = "armv7l" ] ; then
@@ -13,9 +14,9 @@ else
    exit 1
 fi
 
-echo "Executing ${1} operation for ${ARM_VERSION} target architecture"
+echo "Executing ${ACTION} action for ${ARM_VERSION} target architecture"
 
 for i in "${folders[@]}"
 do
-    cd $HERE/$i && make ci-${ARM_VERSION}-${1}
+    cd $HERE/$i && make ci-${ARM_VERSION}-${ACTION}
 done

--- a/contrib/ci-arm.sh
+++ b/contrib/ci-arm.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+HERE=`pwd`
+ARCH=$(uname -m)
+declare -a folders=("of-builder" "router" "auth")
+
+if [ "$ARCH" = "armv7l" ] ; then
+   ARM_VERSION="armhf"
+elif [ "$ARCH" = "aarch64" ] ; then
+   ARM_VERSION="arm64"
+else
+   echo "Not running on ARM. Exiting..."
+   exit 1
+fi
+
+echo "Executing ${1} operation for ${ARM_VERSION} target architecture"
+
+for i in "${folders[@]}"
+do
+    cd $HERE/$i && make ci-${ARM_VERSION}-${1}
+done

--- a/of-builder/Makefile
+++ b/of-builder/Makefile
@@ -5,3 +5,15 @@ build:
 
 push:
 	docker push openfaas/of-builder:$(OF_BUILDER_TAG)
+
+ci-armhf-build:
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/of-builder:$(OF_BUILDER_TAG)-armhf .
+
+ci-armhf-push:
+	docker push openfaas/of-builder:$(OF_BUILDER_TAG)-armhf
+
+ci-arm64-build:
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/of-builder:$(OF_BUILDER_TAG)-arm64 .
+
+ci-arm64-push:
+	docker push openfaas/of-builder:$(OF_BUILDER_TAG)-arm64

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.10-alpine AS builder
-
+RUN apk add --no-cache g++
 WORKDIR /go/src/github.com/openfaas/openfaas-cloud/router
 
 COPY main.go            .

--- a/router/Makefile
+++ b/router/Makefile
@@ -5,3 +5,15 @@ build:
 
 push:
 	docker push openfaas/cloud-router:$(TAG)
+
+ci-armhf-build:
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/cloud-router:$(TAG)-armhf .
+
+ci-armhf-push:
+	docker push openfaas/cloud-router:$(TAG)-armhf
+
+ci-arm64-build:
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/cloud-router:$(TAG)-arm64 .
+
+ci-arm64-push:
+	docker push openfaas/cloud-router:$(TAG)-arm64


### PR DESCRIPTION
## Description
* All architectures can use the same Dockerfiles
* Added a script similar to `publish-arm.sh` that is used for building each component. This way it's easier to extend in future and it also takes into account the host architecture it's being run from.
* There are single `make ci-arm**-*` targets in the main Makefile that trigger a build for all configured components. Or you can hop into each folder and build it separately. 
* A simple `ci-arm-build` was going to be enough as well since the script is aware of the host arch, but decided to keep the same make style as we have so far. This will be helpful if at some point we decide to add this repo to the more general `publish-arm.sh` script and it will work out of the box.

Closes: https://github.com/openfaas/openfaas-cloud/issues/392
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested if the images are building successfully.

## How are existing users impacted? What migration steps/scripts do we need?



## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests