### PR TITLE
Update sealed secrets instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -631,18 +631,21 @@ Access the dashboard via: http://gateway_ip:port/functions/system-dashboard/user
 
 The support for SealedSecrets is optional.
 
-* Add the CRD entry for SealedSecret:
+* Install SealedSecrets from chart:
 
 ```sh
-release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
-kubectl create -f https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/sealedsecret-crd.yaml
+helm install --namespace kube-system --name ofc-sealedsecrets stable/sealed-secrets
 ```
 
-* Install the CRD controller to manage SealedSecrets:
-
-```sh
-kubectl apply -f https://github.com/bitnami-labs/sealed-secrets/releases/download/$release/controller.yaml
-```
+> Note: If you're having issues with already existing CRD, like:
+>```
+>Error: release ofc-sealedsecrets failed: clusterroles.rbac.authorization.k8s.io "secrets-unsealer" already exists
+>```
+>run the following before `helm install`
+>```
+>helm del --purge ofc-sealedsecrets
+>kubectl delete customresourcedefinition sealedsecrets.bitnami.com
+>```
 
 * Install kubeseal CLI
 


### PR DESCRIPTION
This updates the instructions to install sealed secrets from helm chart

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

Closes [ofc-bootstrap/#55](https://github.com/openfaas-incubator/ofc-bootstrap/issues/55)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testes with ofc-bootstrap 

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests N/A