### PR TITLE
[WIP] Adding armhf support for openfaas-cloud

### DIFF
--- a/dashboard/stack.armhf.yml
+++ b/dashboard/stack.armhf.yml
@@ -1,0 +1,14 @@
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  system-dashboard:
+    lang: node8-express-armhf
+    handler: ./of-cloud-dashboard
+    image: functions/of-cloud-dashboard:0.3.3-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment_file:
+      - dashboard_config.yml

--- a/docs/DEPLOY_ARMHF.md
+++ b/docs/DEPLOY_ARMHF.md
@@ -1,0 +1,69 @@
+# Deploying openfaas cloud on armhf
+
+## Prerequisites
+
+1. A domain name which can point to your deployment. (subdomain names also work)
+2. Setup Github app. Refer [this](https://docs.openfaas.com/openfaas-cloud/self-hosted/github/). You'll need to transfer the downloaded `private-key.pem` file to arm device.
+3. Docker hub account.
+
+## Core components steps:
+1. Sign in to docker hub on your machine using:
+
+```bash
+DOCKER_USERNAME=(enter your docker username)
+DOCKER_PASSWORD=(enter your docker password)
+docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+```
+
+2. You'll need to set 'registry-secret' and 'payload-secret' using command
+```bash
+cat $HOME/.docker/config.json | docker secret create registry-secret -
+
+PAYLOAD_SECRET=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+echo -n "$PAYLOAD_SECRET" | docker secret create payload-secret -
+```
+
+3. Run buildkit and of-builder with
+```bash
+docker rm -f of-buildkit
+docker run -d --net func_functions -d --privileged \
+--restart always \
+--name of-buildkit moby/buildkit:v0.3.3 --addr tcp://0.0.0.0:1234
+
+docker service create --constraint="node.role==manager" \
+ --name of-builder \
+ --env insecure=false --detach=true --network func_functions \
+ --secret src=registry-secret,target="/home/app/.docker/config.json" \
+ --secret src=payload-secret,target="/var/openfaas/secrets/payload-secret" \
+ --env enable_lchown=false \
+zeerorg/of-builder:armhf
+```
+4. Setup Github app secrets
+
+```bash
+WEBHOOK_SECRET="Long-Password-Phrase-Goes-Here"
+echo -n "$WEBHOOK_SECRET" | docker secret create github-webhook-secret -
+
+docker secret create private-key "location of private-key.pem"
+```
+
+5. Deploy minio using:
+```bash
+SECRET_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+ACCESS_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+docker service rm minio
+
+docker service create --constraint="node.role==manager" \
+ --name minio \
+ --detach=true --network func_functions \
+ --secret s3-access-key \
+ --secret s3-secret-key \
+ --env MINIO_SECRET_KEY_FILE=s3-secret-key \
+ --env MINIO_ACCESS_KEY_FILE=s3-access-key \
+zeerorg/minio-armhf:latest server /export
+```
+
+6. Change `gateway_config.yml` and remove all occurences of `.openfaas` (standard step for docker swarm)
+
+7. `faas-cli deploy -f stack.armhf.yml` and you should be good to go
+

--- a/docs/DEPLOY_ARMHF.md
+++ b/docs/DEPLOY_ARMHF.md
@@ -6,7 +6,7 @@
 2. Setup Github app. Refer [this](https://docs.openfaas.com/openfaas-cloud/self-hosted/github/). You'll need to transfer the downloaded `private-key.pem` file to arm device.
 3. Docker hub account.
 
-## Core components steps:
+## Core components steps (with docker swarm):
 1. Sign in to docker hub on your machine using:
 
 ```bash
@@ -63,11 +63,72 @@ docker service create --constraint="node.role==manager" \
 zeerorg/minio-armhf:latest server /export
 ```
 
-6. Change `gateway_config.yml`
+7. Change `gateway_config.yml`
  - remove all occurences of `.openfaas` (standard step for docker swarm)
  - Set `gateway_public_url` as the dns domain pointing to the IP address of machine
  - Set `repository_url` and `push_repository_url` as "docker.io/{dockerhub_username}/"
  - Set `s3_url` to "minio:9000"
 
-7. `faas-cli deploy -f stack.armhf.yml` and you should be good to go
+7. `faas-cli deploy -f stack.armhf.yml` to deploy all the main functions.
+
+8. Install `auth` for github oauth:
+   1. Create public and private keys for jwt token:
+      ```bash
+      # Private key
+      openssl ecparam -genkey -name prime256v1 -noout -out key
+
+      # Public key
+      openssl ec -in key -pubout -out key.pub
+      ```
+   2. Store github app client secret:
+      ```bash
+      CLIENT_SECRET = "github app client secret"
+      echo -n "${CLIENT_SECRET}" | docker secret create of-client-secret -
+      ```
+   3. Run auth service:
+      ```bash
+      docker service create --name auth \
+      -e oauth_client_secret_path="/run/secrets/of-client-secret" \
+      -e client_id="$CLIENT_ID" \
+      -e PORT=8080 \
+      -p 8085:8080 \
+      -e external_redirect_domain="http://auth.system.subdomain:8081/" \
+      -e cookie_root_domain=".system.subdomain" \
+      -e public_key_path=/run/secrets/jwt-public-key \
+      -e private_key_path=/run/secrets/jwt-private-key \
+      -e oauth_provider="github" \
+      --secret jwt-private-key \
+      --secret jwt-public-key \
+      --secret of-client-secret \
+      --network func_functions \
+      zeerorg/cloud-auth:armhf
+      ```
+    4. In the next step setup router to get github oauth url which can be set. That is, the oauth setup is complete after you deploy router.
+    
+9. Install `router` for doamin based URL
+   1. Run command
+      ```bash
+      docker service rm of-router
+
+      docker service create --network=func_functions \
+       --env upstream_url=http://gateway:8080 \
+       --env auth_url=http://auth:8080 \
+       --publish 8081:8080 \
+       --name of-router \
+       -d zeerorg/cloud-router:armhf
+       ```
+   2. Your main url is now exposed at port http://subdomain:8081/
+   3. Setup your "User authorization callback url" in the github app page to: "http://auth.system.subdomain:8081/"
+
+10. Dashboard Install:
+    1. Go into `/dashboard/` directory. Edit `dashboard_config.yml`
+       - Remove `.openfaas` from `gateway_url`
+       - Set `public_url` to `http://system.subdomain:8081/`
+       - Set `pretty_url` to `http://user.subdomain:8081/function`
+       - Set `base_href` to '/dashboard/'
+    2. Deploy dashboard with:
+       ```bash
+       faas-cli template pull https://github.com/openfaas-incubator/node8-express-template
+       faas-cli deploy --filter "system-dashboard" -f ./stack.armhf.yml
+       ```
 

--- a/docs/DEPLOY_ARMHF.md
+++ b/docs/DEPLOY_ARMHF.md
@@ -51,6 +51,10 @@ docker secret create private-key "location of private-key.pem"
 ```bash
 SECRET_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
 ACCESS_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
+
+echo $SECRET_KEY | docker secret create s3-secret-key -
+echo $ACCESS_KEY | docker secret create s2-access-key -
+
 docker service rm minio
 
 docker service create --constraint="node.role==manager" \

--- a/docs/DEPLOY_ARMHF.md
+++ b/docs/DEPLOY_ARMHF.md
@@ -121,7 +121,7 @@ zeerorg/minio-armhf:latest server /export
    3. Setup your "User authorization callback url" in the github app page to: "http://auth.system.subdomain:8081/"
 
 10. Dashboard Install:
-    1. Go into `/dashboard/` directory. Edit `dashboard_config.yml`
+    1. Go into `dashboard/` directory. Edit `dashboard_config.yml`
        - Remove `.openfaas` from `gateway_url`
        - Set `public_url` to `http://system.subdomain:8081/`
        - Set `pretty_url` to `http://user.subdomain:8081/function`

--- a/docs/DEPLOY_ARMHF.md
+++ b/docs/DEPLOY_ARMHF.md
@@ -63,7 +63,11 @@ docker service create --constraint="node.role==manager" \
 zeerorg/minio-armhf:latest server /export
 ```
 
-6. Change `gateway_config.yml` and remove all occurences of `.openfaas` (standard step for docker swarm)
+6. Change `gateway_config.yml`
+ - remove all occurences of `.openfaas` (standard step for docker swarm)
+ - Set `gateway_public_url` as the dns domain pointing to the IP address of machine
+ - Set `repository_url` and `push_repository_url` as "docker.io/{dockerhub_username}/"
+ - Set `s3_url` to "minio:9000"
 
 7. `faas-cli deploy -f stack.armhf.yml` and you should be good to go
 

--- a/docs/DEPLOY_ARMHF.md
+++ b/docs/DEPLOY_ARMHF.md
@@ -53,7 +53,7 @@ SECRET_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
 ACCESS_KEY=$(head -c 12 /dev/urandom | shasum| cut -d' ' -f1)
 
 echo $SECRET_KEY | docker secret create s3-secret-key -
-echo $ACCESS_KEY | docker secret create s2-access-key -
+echo $ACCESS_KEY | docker secret create s3-access-key -
 
 docker service rm minio
 

--- a/git-tar/Dockerfile
+++ b/git-tar/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.10.4-alpine3.7 as build
 
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from GitHub." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.5/fwatchdog > /usr/bin/fwatchdog \
-    && curl -sSL https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli > /usr/local/bin/faas-cli \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.5/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli-armhf > /usr/local/bin/faas-cli \
     && chmod +x /usr/bin/fwatchdog \
     && chmod +x /usr/local/bin/faas-cli \
     && apk del curl --no-cache

--- a/git-tar/Dockerfile
+++ b/git-tar/Dockerfile
@@ -2,8 +2,9 @@ FROM golang:1.10.4-alpine3.7 as build
 
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from GitHub." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.5/fwatchdog-armhf > /usr/bin/fwatchdog \
-    && curl -sSL https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli-armhf > /usr/local/bin/faas-cli \
+    && if [ "$(uname -m)" = "armv7l" ]; then arch="-armhf"; else arch=""; fi \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.5/fwatchdog$arch > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli$arch > /usr/local/bin/faas-cli \
     && chmod +x /usr/bin/fwatchdog \
     && chmod +x /usr/local/bin/faas-cli \
     && apk del curl --no-cache

--- a/stack.armhf.yml
+++ b/stack.armhf.yml
@@ -1,0 +1,204 @@
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+
+functions:
+  system-github-event:
+    lang: go-armhf
+    handler: ./github-event
+    image: functions/github-event:0.7.1-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      validate_hmac: true
+      write_debug: true
+      read_debug: true
+      validate_customers: true
+    environment_file:
+      - github.yml
+      - gateway_config.yml
+    secrets:
+      - github-webhook-secret
+      - payload-secret
+
+  github-push:
+    lang: go-armhf
+    handler: ./github-push
+    image: functions/github-push:0.7.1-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      validate_hmac: true
+      read_timeout: 10s
+      write_timeout: 10s
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - github-webhook-secret
+      - payload-secret
+
+  git-tar:
+    lang: dockerfile
+    handler: ./git-tar
+    image: functions/of-git-tar:0.9.1-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      read_timeout: 15m
+      write_timeout: 15m
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - payload-secret
+      - private-key
+# Uncomment this for GitLab
+#      - gitlab-api-token
+
+  buildshiprun:
+    lang: go-armhf
+    handler: ./buildshiprun
+    image: functions/of-buildshiprun:0.9.2-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      read_timeout: 5m
+      write_timeout: 5m
+      write_debug: true
+      read_debug: true
+      scaling_factor: 50
+    environment_file:
+      - buildshiprun_limits.yml
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+      - payload-secret
+#      - swarm-pull-secret
+
+  garbage-collect:
+    lang: go-armhf
+    handler: ./garbage-collect
+    image: functions/garbage-collect:0.4.3-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      read_timeout: 30s
+      write_timeout: 30s
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+      - payload-secret
+
+  github-status:
+    lang: go-armhf
+    handler: ./github-status
+    image: functions/github-status:0.3.5-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+      validate_hmac: true
+      debug_token: true
+    environment_file:
+      - gateway_config.yml
+      - github.yml
+    secrets:
+      - private-key
+      - payload-secret
+
+  import-secrets:
+    lang: go-armhf
+    handler: ./import-secrets
+    image: functions/import-secrets:0.3.2-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      validate_hmac: true
+      combined_output: false
+    environment_file:
+      - github.yml
+    secrets:
+      - payload-secret
+
+  pipeline-log:
+    lang: go-armhf
+    handler: ./pipeline-log
+    image: functions/pipeline-log:0.3.2-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+      combine_output: false
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - s3-access-key
+      - s3-secret-key
+      - payload-secret
+
+  list-functions:
+    lang: go-armhf
+    handler: ./list-functions
+    image: functions/list-functions:0.4.7-armhf
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+    environment:
+      write_debug: true
+      read_debug: true
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - basic-auth-user
+      - basic-auth-password
+
+  audit-event:
+    lang: go-armhf
+    handler: ./audit-event
+    image: functions/audit-event:0.1.1-armhf
+    labels:
+      openfaas-cloud: "1"
+    environment_file:
+      - slack.yml
+
+  echo:
+    skip_build: true
+    image: functions/alpine:latest-armhf
+    fprocess: cat
+    environment:
+      write_debug: true
+      read_debug: true
+
+  system-metrics:
+    lang: go-armhf
+    handler: ./system-metrics
+    image: functions/system-metrics:0.1.0-armhf
+    environment_file:
+      - gateway_config.yml
+    environment:
+      content_type: "application/json"
+


### PR DESCRIPTION
Signed-off-by: Rishabh Gupta<r.g.gupta@outlook.com>

## Description
This PR is a work in progress to add support for openfaas cloud on armv7 devices.
Currenty it has been only tested with docker swarm on scaleway arm server.

## How Has This Been Tested?
The openfaas cloud was setup and run on a scaleway arm server under docker swarm.

## How are existing users impacted? What migration steps/scripts do we need?
Existing users are not impacted. The necessary steps to deploy and test the PR have been given in the DEPLOY_ARMHF.md file

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

## Roadmap

- [x] Document steps for deployment
- [x] Create new stack.yml which references armhf functions
- [x] Add steps for dashboard
- [x] Find out a way to configure of-git-tar (function based on dockerfile, doesn't have armhf template)
- [ ] Build and push all functions and services (of-builder, router, auth, dashboard) (currently being done by pr #394 )
- [ ] Add steps for scenario without an available domain name.
