### PR TITLE
Dashboard trailing slash url bug

### DIFF
--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -10,7 +10,7 @@ const genLogPath = ({ shortName, gitOwner, gitRepo, gitSha }, user) => (
 );
 
 const genFnDetailPath = ({ shortName, gitOwner, gitRepo }, user) => (
-  `${user}/${shortName}?repoPath=${gitOwner}/${gitRepo}`
+  `/${user}/${shortName}?repoPath=${gitOwner}/${gitRepo}`
 );
 
 const genRepoUrl = ({ gitOwner, gitRepoURL }) => (


### PR DESCRIPTION
Signed-off-by: Rishabh Gupta<r.g.gupta@outlook.com>

## Description
when you open user dashboard with a trailing slash and go to a specific function deployed by the user the url is wrong and hence the function is not loaded correctly.

Duplicating the bug:

1. Open : https://system.o6s.io/dashboard/alexellis/
2. Click on any function and there will be a "Page not found"

## How Has This Been Tested?
Tested this on a arm deployment. http://system.o6s.zeerorg.site/dashboard/alexellis/ works fine since the patch has been applied.

## How are existing users impacted? What migration steps/scripts do we need?
The existing users are not impacted.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
