### PR TITLE
Add node10-express custom template

### DIFF
--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -8,7 +8,7 @@ environment:
   gateway_pretty_url: https://user.o6s.io/function
   # Add your custom templates by adding a coma separated URL, i.e. extend the current value with:
   # ", https://github.com/custom/template.git, https://github.com/custom/template2.git"
-  custom_templates: "https://github.com/openfaas-incubator/node8-express-template.git, https://github.com/openfaas-incubator/golang-http-template.git"
+  custom_templates: "https://github.com/openfaas-incubator/node8-express-template.git, https://github.com/openfaas-incubator/golang-http-template.git, https://github.com/openfaas-incubator/node10-express-template.git"
 
 # Security
   customers_url: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"

--- a/git-tar/function/ops_test.go
+++ b/git-tar/function/ops_test.go
@@ -108,6 +108,7 @@ func Test_formatTemplateReposValid(t *testing.T) {
 		"https://github.com/openfaas/templates",
 		"https://github.com/openfaas-incubator/node8-express-template.git",
 		"https://github.com/openfaas-incubator/golang-http-template.git",
+		"https://github.com/openfaas-incubator/node10-express-template.git",
 	}
 
 	tests := []struct {
@@ -157,6 +158,7 @@ func Test_formatTemplateReposUnvalid(t *testing.T) {
 		"https://github.com/openfaas/templates",
 		"https://github.com/openfaas-incubator/node8-express-template.git",
 		"https://github.com/openfaas-incubator/golang-http-template.git",
+		"https://github.com/openfaas-incubator/node10-express-template.git",
 	}
 
 	tests := []struct {


### PR DESCRIPTION
Signed-off-by: Brian Woodward <brian.woodward@gmail.com>

## Description

- Add node10-express-template repository to gateway_config.yml as a default custom template to use.
- Update opts_test to ensure the node10-express template will be included in the check.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [X] added unit tests
