### PR TITLE
Change node8-express to node10-express

### DIFF
--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -1,4 +1,4 @@
 .PHONY: build
 
 build:
-	( docker run -v $(shell pwd):/dashboard node:8-alpine /bin/sh -c "cd dashboard/client && yarn && yarn run build")
+	( docker run -v $(shell pwd):/dashboard node:10.20.0-alpine /bin/sh -c "cd dashboard/client && yarn && yarn build")

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -89,10 +89,10 @@ cookie_root_domain: ".system.o6s.io"
 
 **Deploy**
 
-> Don't forget to pull the `node8-express-template`
+> Don't forget to pull the `node10-express-template`
 
 ```
-$ faas-cli template pull https://github.com/openfaas-incubator/node8-express-template
+$ faas-cli template pull https://github.com/openfaas-incubator/node10-express-template
 $ faas-cli up
 ```
 

--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -4,7 +4,7 @@ provider:
 
 functions:
   system-dashboard:
-    lang: node8-express
+    lang: node10-express
     handler: ./of-cloud-dashboard
     image: functions/of-cloud-dashboard:0.3.3
     labels:

--- a/docs/README.md
+++ b/docs/README.md
@@ -611,12 +611,12 @@ Set `public_url` to be the URL for the IP / DNS of the OpenFaaS Cloud.
 
 **Deploy**
 
-> Don't forget to pull the `node8-express-template`
+> Don't forget to pull the `node10-express-template`
 
 ```
 $ cd dashboard
 
-$ faas-cli template pull https://github.com/openfaas-incubator/node8-express-template
+$ faas-cli template pull https://github.com/openfaas-incubator/node10-express-template
 ```
 
 > Note: if using dockerhub change the `function` prefix in `stack.yml` with your username


### PR DESCRIPTION
Changed node8-express-template to node10-express-template,
updated make file in accordance with node version used in node10-express-template,
updated READMEs.

Signed-off-by: Marko <marbar3778@yahoo.com>

## Description
Fixes #410 


## How Has This Been Tested?
Deployed the dashboard locally. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?



## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
