### PR TITLE
Add documentation for custom templates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -669,6 +669,20 @@ kubeseal --fetch-cert > pub-cert.pem
 
 You will need to distribute or share pub-cert.pem so that people can use this with the OpenFaaS CLI `faas-cli cloud seal` command to seal secrets.
 
+### Custom templates
+
+You can add your own custom templates by re-deploying the `git-tar` function in `stack.yml`.
+
+In order to do that follow the steps below:
+* Navigate to `gateway_config.yml`:
+  * Under `environment` key you should be able to locate `custom_templates` in which you can see listed templates.
+  * Append your own template to the list.
+
+* Re-deploy `git-tar` function from your `stack.yml` with the changed configuration:
+```sh
+$ faas-cli deploy --filter git-tar --gateway=<of_gateway_url>
+```
+
 ### Wildcard domains with of-router
 
 Coming soon


### PR DESCRIPTION
Adding documentation for custom template
feature which tells you how to re-deploy
OF git-tar function to apply the new
configuration with appended custom template

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

Documentation on custom templates was needed since it was not very obvious.

Closes #419 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

## How are existing users impacted? What migration steps/scripts do we need?

They will be able to have a place to check how to deploy their own custom templates.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
