### PR TITLE
Add support for dockerfile template

### DIFF
--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -34,6 +34,9 @@ environment:
   prometheus_port: 9090
   metrics_window: 60m
 
+  # Enable support for the dockerfile template
+  enable_dockerfile_lang: false
+
 # To use a shared Docker Hub account.
 #  repository_url: docker.io/ofcommunity/
 #  push_repository_url: docker.io/ofcommunity/

--- a/git-tar/Dockerfile
+++ b/git-tar/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.10.4-alpine3.7 as build
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from GitHub." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.5/fwatchdog > /usr/bin/fwatchdog \
-    && curl -sSL https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli > /usr/local/bin/faas-cli \
+    && curl -sSL https://github.com/openfaas/faas-cli/releases/download/0.8.6/faas-cli > /usr/local/bin/faas-cli \
     && chmod +x /usr/bin/fwatchdog \
     && chmod +x /usr/local/bin/faas-cli \
     && apk del curl --no-cache

--- a/git-tar/function/handler_test.go
+++ b/git-tar/function/handler_test.go
@@ -2,6 +2,8 @@ package function
 
 import (
 	"testing"
+
+	"github.com/openfaas/faas-cli/stack"
 )
 
 func Test_getRawURL(t *testing.T) {
@@ -50,4 +52,40 @@ func Test_getRawURL(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_hasDockerfileFunction(t *testing.T) {
+	var cases = []struct {
+		title    string
+		input    map[string]stack.Function
+		expected bool
+	}{
+		{
+			title: "no dockerfile function",
+			input: map[string]stack.Function{
+				"test": stack.Function{
+					Language: "go",
+				},
+			},
+			expected: false,
+		},
+		{
+			title: "with a dockerfile function",
+			input: map[string]stack.Function{
+				"test": stack.Function{
+					Language: "Dockerfile",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			result := hasDockerfileFunction(c.input)
+			if result != c.expected {
+				t.Errorf("Expected %v but got %v instead", c.expected, result)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
This PR adds support for the dockerfile template. In order to enable support users have to set `enable_dockerfile_lang` to true, it is false by default.
In order for this to be implemented the following changes were introduced:
* Update git-tar's faas-cli version to 0.8.6
* Modify git-tar to check if there are dockerfile functions and if the feature is enabled or not

Fixes #421 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this using my own ofc installation and deploying [matipan/of-git-tar:dockerfileSupport](https://hub.docker.com/r/matipan/of-git-tar). Test cases:
* **If the feature is enabled and there is a dockerfile function**: [here](https://github.com/matipan/dtest/runs/84836104) you can see that the build and deploy was successful
* **If the feature is disabled and there is a dockerfile function**: [here](https://github.com/matipan/dtest/runs/84843643) you can see that the build failed with the error message: _detected a dockerfile function but feature is not enabled_
* **If the feature is enabled/disabled a function that it's not dockerfile can be successfully deployed**: I validated this using the e2e test from [this PR](https://github.com/openfaas/openfaas-cloud/pull/418)

## How are existing users impacted? What migration steps/scripts do we need?
Users will not be impacted since the feature is disabled by default.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
