### PR TITLE
Add CPU limiting

### DIFF
--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -239,6 +239,44 @@ func Test_getMemoryLimit_Kubernetes(t *testing.T) {
 	}
 }
 
+func Test_getCPULimit_Kubernetes(t *testing.T) {
+	tests := []struct {
+		title         string
+		limitValue    string
+		expectedLimit string
+		wantAvailable bool
+	}{
+		{
+			title:         "Override test - Kubernetes environment variables present and limit is set",
+			limitValue:    "250",
+			expectedLimit: "250m",
+			wantAvailable: true,
+		},
+		{
+			title:         "Defaults test - Kubernetes environment variables present and limit is unset",
+			limitValue:    "",
+			expectedLimit: "",
+			wantAvailable: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			os.Setenv("KUBERNETES_SERVICE_PORT", "6443")
+			os.Setenv("function_cpu_limit_milli", test.limitValue)
+
+			limit := getCPULimit()
+			if limit.Available != test.wantAvailable {
+				t.Errorf("Limits not available, want: %v, got: %v", test.wantAvailable, limit.Available)
+			}
+
+			if limit.Limit != test.expectedLimit {
+				t.Errorf("Limits not correct, want: `%v` got: `%v`.", test.expectedLimit, limit.Limit)
+			}
+		})
+	}
+}
+
 func Test_existingVariable_Existent(t *testing.T) {
 	tests := []struct {
 		title string

--- a/buildshiprun_limits.yml
+++ b/buildshiprun_limits.yml
@@ -1,3 +1,5 @@
 environment:
-  function_memory_limit_mb: 128 #The differences in formatting are handled by buildshiprun
-  
+  function_memory_limit_mb: 128   # The differences in formatting are handled by buildshiprun
+# https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/#specify-a-cpu-request-and-a-cpu-limit
+  function_cpu_requests_milli: 100        # Available on Kubernetes only, CPU in milliCPU
+  function_cpu_limit_milli: 500           # Available on Kubernetes only, CPU in milliCPU

--- a/stack.yml
+++ b/stack.yml
@@ -66,7 +66,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: functions/of-buildshiprun:0.9.3
+    image: functions/of-buildshiprun:0.10.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

Adds CPU requests and limits for use with Kubernetes only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on OpenFaaS Cloud Community Cluster: my function received
a CPU limit and requests value.

Unit tests added.

## How are existing users impacted? What migration steps/scripts do we need?

Fixes: #424

User can opt to update to this version of the function. `buildshiprun_limits.yml` can be left as-is without a value for CPU or this can be added manually as per the example in master.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
