### PR TITLE
Add user labels feature

### DIFF
--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -6,6 +6,33 @@ import (
 	"testing"
 )
 
+func TestGetEvent_ReadLabels(t *testing.T) {
+
+	want := map[string]string{
+		"com.openfaas.scale": "true",
+	}
+
+	val, _ := json.Marshal(want)
+	os.Setenv("Http_Labels", string(val))
+
+	eventInfo, err := getEventFromEnv()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	for k, v := range want {
+		if _, ok := eventInfo.Labels[k]; !ok {
+			t.Errorf("want %s to be present in event.Labels", k)
+			continue
+		}
+		if vv, _ := eventInfo.Labels[k]; vv != v {
+			t.Errorf("value of %s, want: %s, got %s", k, v, vv)
+		}
+
+	}
+}
+
 func TestGetEvent_ReadSecrets(t *testing.T) {
 
 	valSt := []string{"s1", "s2"}

--- a/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
+++ b/buildshiprun/vendor/github.com/openfaas/openfaas-cloud/sdk/events.go
@@ -69,6 +69,7 @@ type Event struct {
 	Private        bool              `json:"private"`
 	SCM            string            `json:"scm"`
 	RepoURL        string            `json:"repourl"`
+	Labels         map[string]string `json:"labels"`
 }
 
 // BuildEventFromPushEvent function to build Event from PushEvent

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -410,6 +410,16 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services, sta
 
 		httpReq.Header.Add("Secrets", string(secretsJSON))
 
+		// Marshal user labels
+		if stack.Functions[tarEntry.functionName].Labels != nil {
+			labelsJSON, marshalErr := json.Marshal(stack.Functions[tarEntry.functionName].Labels)
+			if marshalErr != nil {
+				log.Printf("Error marshaling labels for function %s, %s", tarEntry.functionName, marshalErr)
+			}
+
+			httpReq.Header.Add("Labels", string(labelsJSON))
+		}
+
 		res, reqErr := c.Do(httpReq)
 		if reqErr != nil {
 			failedFunctions = append(failedFunctions, tarEntry.functionName)

--- a/stack.yml
+++ b/stack.yml
@@ -45,7 +45,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.10.0
+    image: functions/of-git-tar:0.11.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -66,7 +66,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: functions/of-buildshiprun:0.10.0
+    image: functions/of-buildshiprun:0.10.1
     labels:
       openfaas-cloud: "1"
       role: openfaas-system

--- a/stack.yml
+++ b/stack.yml
@@ -45,7 +45,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.9.2
+    image: functions/of-git-tar:0.10.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Description

Allows users to pass their own values through stack.yml. These
still need to be consumed within buildshiprun and then forwarded
to the deployment request.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with unit tests.

Tested end-to-end on live environment with:

* 1x function with a label override to prevent scaling to zero (got com.openfaas.scale.zero=false)
* 1x function without a label to prevent scaling to zero (got com.openfaas.scale.zero=true)

## How are existing users impacted? What migration steps/scripts do we need?

Sync the versions in ofc-bootstrap's stack.yml template so that users can benefit when they upgrade.

No immediate impact since faasIdler is off by default.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
