### PR TITLE
Add building from different branches GitLab

### DIFF
--- a/gitlab-push/handler_test.go
+++ b/gitlab-push/handler_test.go
@@ -1,6 +1,8 @@
 package function
 
 import (
+	"errors"
+	"os"
 	"testing"
 )
 
@@ -35,4 +37,120 @@ func Test_checkPublicRepo(t *testing.T) {
 		})
 	}
 
+}
+func Test_filterBranchRef(t *testing.T) {
+	tests := []struct {
+		title          string
+		branchRef      string
+		expectedBranch string
+	}{
+		{
+			title:          "Expected format",
+			branchRef:      "some/format/master",
+			expectedBranch: "master",
+		},
+		{
+			title:          "Unexpected format",
+			branchRef:      "dev",
+			expectedBranch: "dev",
+		},
+		{
+			title:          "No value",
+			branchRef:      "",
+			expectedBranch: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			branch := filterBranchRef(test.branchRef)
+			if test.expectedBranch != branch {
+				t.Errorf("Expected branch: `%s` got: `%s`", test.expectedBranch, branch)
+			}
+
+		})
+	}
+}
+func Test_getBranch(t *testing.T) {
+	tests := []struct {
+		title          string
+		branchInEnv    string
+		expectedBranch string
+	}{
+		{
+			title:          "Expected format",
+			branchInEnv:    "master",
+			expectedBranch: "master",
+		},
+		{
+			title:          "Expected format with spaces",
+			branchInEnv:    " master ",
+			expectedBranch: "master",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			os.Setenv("build_branch", test.branchInEnv)
+			branch := getBranch()
+			if branch != test.expectedBranch {
+				t.Errorf("Value: `%s` not found in expected cases: `%v`", branch, test.expectedBranch)
+			}
+		})
+	}
+}
+
+func Test_getBranch_unsetEnv(t *testing.T) {
+	expectedBranch := "master"
+	branch := getBranch()
+	t.Run("Test when env var build_branch is unset", func(t *testing.T) {
+		if branch != expectedBranch {
+			t.Errorf("Value: `%s` not found in expected cases: `%v`", branch, expectedBranch)
+		}
+	})
+}
+func Test_checkBranch(t *testing.T) {
+	tests := []struct {
+		title         string
+		branchesInEnv string
+		branchRef     string
+		expectedError error
+	}{
+
+		{
+			title:         "Branch exists in environmental variables",
+			branchesInEnv: "master",
+			branchRef:     "refs/heads/master",
+			expectedError: nil,
+		},
+
+		{
+			title:         "Branch does not exist in environmental variables",
+			branchesInEnv: "staging",
+			branchRef:     "/refs/heads/development",
+			expectedError: errors.New("refusing to build target branch: development, want branch: staging"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			os.Setenv("build_branch", test.branchesInEnv)
+			branchErr := checkBranch(test.branchRef)
+			if branchErr != test.expectedError && branchErr != nil {
+				if branchErr.Error() != test.expectedError.Error() {
+					t.Errorf("Expected error: `%s`, got: `%s`",
+						test.expectedError.Error(),
+						branchErr.Error())
+				}
+			}
+		})
+	}
+}
+
+func Test_checkBranch_unsetBranchInEnv(t *testing.T) {
+	t.Run("Environmental variable does not exist, only master accepted", func(t *testing.T) {
+		os.Unsetenv("build_branch")
+		branchRef := "/refs/heads/master"
+		branchErr := checkBranch(branchRef)
+		if branchErr != nil {
+			t.Errorf("Expected error to be nil got: `%s`", branchErr.Error())
+		}
+	})
 }

--- a/gitlab.yml
+++ b/gitlab.yml
@@ -24,7 +24,7 @@ functions:
     secrets:
       - gitlab-webhook-secret
       - payload-secret
-      - gitlab-api-token 
+      - gitlab-api-token
 
   gitlab-status:
     lang: go
@@ -41,8 +41,8 @@ functions:
       - gateway_config.yml
     secrets:
       - gitlab-api-token
-      - payload-secret 
-      
+      - payload-secret
+
   gitlab-push:
     lang: go
     handler: ./gitlab-push
@@ -54,8 +54,8 @@ functions:
     environment:
       write_debug: true
       read_debug: true
+      build_branch: "master"
     environment_file:
       - gateway_config.yml
     secrets:
       - payload-secret
- 


### PR DESCRIPTION
Adding functionality which will ebable building functions
from multiple branches for gitlab-event function by adding
branches environmental variable with comma separated list

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

In Issue #425 me and @matipan agreed to split tasks, he did the majority of the Issue covering git-tar along with GitHub and dashboard this part covers GitLab only so I won't be closing the Issue with this PR.

Conceptual this covers gitlab-push only and you set `branches` environmental variable with comma separated list like so: `master,dev,staging` to enable which branches you would like to be able to build functions from. If unset, defaults to `master` branch only

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit testing and manual tests here environmental `branches` set to `newbranch`:

### Building master branch fails:
![image](https://user-images.githubusercontent.com/34942004/56469764-85652f00-6446-11e9-87dd-5a60d7cc8e4c.png)
### Building newbranch succeeds:
![image](https://user-images.githubusercontent.com/34942004/56469771-9d3cb300-6446-11e9-83f8-9ad7b56d2498.png)

In dashboard function is displayed even when build from non-`master` branch.


## How are existing users impacted? What migration steps/scripts do we need?

They will be able to build functions from different branches depending on their needs.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
