### PR TITLE
Add improved message when template is missing

### DIFF
--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -145,6 +145,17 @@ func Handle(req []byte) []byte {
 		os.Exit(-1)
 	}
 
+	err = checkCompatibleTemplates(stack, clonePath)
+	if err != nil {
+		log.Println("Error while checking available templates:", err.Error())
+		status.AddStatus(sdk.StatusFailure, "missing language template error : "+err.Error(), sdk.StackContext)
+		statusErr := reportStatus(status, pushEvent.SCM)
+		if statusErr != nil {
+			log.Printf(statusErr.Error())
+		}
+		os.Exit(-1)
+	}
+
 	var shrinkWrapPath string
 	shrinkWrapPath, err = shrinkwrap(pushEvent, clonePath)
 	if err != nil {

--- a/stack.yml
+++ b/stack.yml
@@ -63,8 +63,8 @@ functions:
     secrets:
       - payload-secret
       - private-key
-# Uncomment this for GitLab
-#      - gitlab-api-token
+  # Uncomment this for GitLab
+  #      - gitlab-api-token
 
   buildshiprun:
     lang: go
@@ -88,7 +88,7 @@ functions:
       - basic-auth-user
       - basic-auth-password
       - payload-secret
-#      - swarm-pull-secret
+  #      - swarm-pull-secret
 
   garbage-collect:
     lang: go


### PR DESCRIPTION
Adding message which signals that actually the
failure is due to missing template rather than the old
confusing output

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

Closes #417 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually e2e the image containing the change is `martindekov/of-git-tar:0.12.0` in order to test it yourself instead of checking out branches etc. and the status looks like this:
![image](https://user-images.githubusercontent.com/34942004/56471302-a1260080-6459-11e9-8c71-007c385c4c27.png)

## How are existing users impacted? What migration steps/scripts do we need?

Users will now be able to see the actual error of their language not supported/missing/unconfigured instead of directly getting the failed to build error which was confusing

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
