### PR TITLE
Support custom build branches via env variable

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -222,6 +222,7 @@ func Handle(req []byte) string {
 				sdk.FunctionLabelPrefix + "git-sha":        event.SHA,
 				sdk.FunctionLabelPrefix + "git-private":    fmt.Sprintf("%d", private),
 				sdk.FunctionLabelPrefix + "git-scm":        event.SCM,
+				sdk.FunctionLabelPrefix + "git-branch":     buildBranch(),
 				"faas_function":                            serviceValue,
 				"app":                                      serviceValue,
 				"com.openfaas.scale.min":    scalingMinLimit,
@@ -694,4 +695,12 @@ func reportGitLabStatus(status *sdk.Status) {
 		log.Printf("unexpected error while reading response body: %s", bodyErr.Error())
 	}
 	status.CommitStatuses = make(map[string]sdk.CommitStatus)
+}
+
+func buildBranch() string {
+	branch := os.Getenv("build_branch")
+	if branch == "" {
+		return "master"
+	}
+	return branch
 }

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -89,6 +89,7 @@ class FunctionsApi {
         gitDeployTime: item.labels['com.openfaas.cloud.git-deploytime'],
         gitPrivate: isPrivate,
         gitSha: item.labels['com.openfaas.cloud.git-sha'],
+        gitBranch: item.labels['com.openfaas.cloud.git-branch'],
         gitRepoURL: getRepoURL(item.annotations || {}),
         minReplicas: item.labels['com.openfaas.scale.min'],
         maxReplicas: item.labels['com.openfaas.scale.max'],

--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -13,9 +13,12 @@ const genFnDetailPath = ({ shortName, gitOwner, gitRepo }, user) => (
   `/${user}/${shortName}?repoPath=${gitOwner}/${gitRepo}`
 );
 
-const genRepoUrl = ({ gitOwner, gitRepoURL }) => (
-  `${gitRepoURL}/commits/master`
-);
+const genRepoUrl = ({ gitRepoURL, gitBranch }) => {
+  if(gitBranch === "") {
+    return `${gitRepoURL}/commits/master`
+  }
+  return `${gitRepoURL}/commits/${gitBranch}`
+};
 
 const FunctionTableItem = ({ onClick, fn, user }) => {
   const {

--- a/dashboard/overview/handler.go
+++ b/dashboard/overview/handler.go
@@ -14,6 +14,7 @@ type UserData struct {
 	PublicURL      string
 	PrettyURL      string
 	QueryPrettyURL string
+	BuildBranch    string
 }
 
 // Handle a serverless request
@@ -37,6 +38,7 @@ func Handle(req []byte) string {
 
 	userData1.User = user
 	userData1.SelectedRepo = repo
+	userData1.BuildBranch = buildBranch()
 
 	log.Println("User: ", user, " Repo: ", repo)
 
@@ -49,4 +51,12 @@ func Handle(req []byte) string {
 	}
 
 	return tpl.String()
+}
+
+func buildBranch() string {
+	branch := os.Getenv("build_branch")
+	if branch == "" {
+		return "master"
+	}
+	return branch
 }

--- a/dashboard/overview/index.html
+++ b/dashboard/overview/index.html
@@ -93,6 +93,7 @@
             var baseURL = "{{.PublicURL}}";
             var prettyDomain = "{{.PrettyURL}}";
             var queryPrettyURL = "{{.QueryPrettyURL}}";
+            var branch = "{{.BuildBranch}}";
 
             $("#username").text(user);
 
@@ -138,7 +139,7 @@
                     }
 
                     var fullPath = item.labels["com.openfaas.cloud.git-owner"] + "/" + item.labels["com.openfaas.cloud.git-repo"];
-                    var repoLink = '<a href="https://github.com/' + fullPath + '/commits/master">' + item.labels["com.openfaas.cloud.git-repo"] + '</a>';
+                    var repoLink = '<a href="https://github.com/' + fullPath + '/commits/'+ branch +'">' + item.labels["com.openfaas.cloud.git-repo"] + '</a>';
 
                     var rowClass = "";
                     if (item.labels["com.openfaas.cloud.git-repo"] == selectedRepo) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -252,7 +252,7 @@ Create of-builder and of-buildkit:
 ./of-builder/deploy_swarm.sh
 ```
 
-### Configure push repository and gateway URL
+### Configure push repository, gateway URL and build branch
 
 In gateway_config.yml
 
@@ -263,11 +263,14 @@ environment:
   audit_url: http://gateway.openfaas:8080/function/audit-event
   repository_url: docker.io/ofcommunity/
   push_repository_url: docker.io/ofcommunity/
+  build_branch: master
 ```
 
 Replace "ofcommunity" with your Docker Hub account i.e. `alexellis2/cloud/` or replace the whole string with the address of your private registry `reg.my-domain.xyz`.
 
 Now set your gateway's public URL in the `gateway_public_url` field.
+
+Set the branch you want ofc to use in the `build_branch` field.
 
 ### Configure pull secret
 

--- a/gateway_config.yml
+++ b/gateway_config.yml
@@ -37,6 +37,9 @@ environment:
   # Enable support for the dockerfile template
   enable_dockerfile_lang: false
 
+  # Set the build branch to be used by ofc
+  build_branch: master
+
 # To use a shared Docker Hub account.
 #  repository_url: docker.io/ofcommunity/
 #  push_repository_url: docker.io/ofcommunity/

--- a/git-tar/function/format_test.go
+++ b/git-tar/function/format_test.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/openfaas/faas-cli/stack"
@@ -31,10 +32,11 @@ func Test_FormatImageShaTag_PrivateRepo_WithTag_NoStackPrefix(t *testing.T) {
 	owner := "alexellis"
 	repo := "go-fns-tester"
 	sha := "04b8e44988"
+	os.Setenv("build_branch", "master")
 
 	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
 
-	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44"
+	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-master-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
@@ -48,10 +50,11 @@ func Test_FormatImageShaTag_PrivateRepo_WithTag(t *testing.T) {
 	owner := "alexellis"
 	repo := "go-fns-tester"
 	sha := "04b8e44988"
+	os.Setenv("build_branch", "master")
 
 	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
 
-	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-04b8e44"
+	want := "registry:5000/" + owner + "/" + repo + "-func:0.2-master-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
@@ -65,10 +68,11 @@ func Test_FormatImageShaTag_PrivateRepo_NoTag(t *testing.T) {
 	owner := "alexellis"
 	repo := "go-fns-tester"
 	sha := "04b8e44988"
+	os.Setenv("build_branch", "master")
 
 	name := formatImageShaTag("registry:5000", function, sha, owner, repo)
 
-	want := "registry:5000/" + owner + "/" + repo + "-func:latest-04b8e44"
+	want := "registry:5000/" + owner + "/" + repo + "-func:latest-master-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}
@@ -82,10 +86,10 @@ func Test_FormatImageShaTag_SharedRepo_NoTag(t *testing.T) {
 	owner := "alexellis"
 	repo := "go-fns-tester"
 	sha := "04b8e44988"
-
+	os.Setenv("build_branch", "master")
 	name := formatImageShaTag("docker.io/of-community/", function, sha, owner, repo)
 
-	want := "docker.io/of-community/" + owner + "-" + repo + "-func:latest-04b8e44"
+	want := "docker.io/of-community/" + owner + "-" + repo + "-func:latest-master-04b8e44"
 	if name != want {
 		t.Errorf("Want \"%s\", got \"%s\"", want, name)
 	}

--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -335,9 +335,9 @@ func getRawURL(scm string, repositoryURL string, repositoryOwnerLogin string, re
 	rawURL := ""
 	switch scm {
 	case GitHub:
-		rawURL = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/master/stack.yml", repositoryOwnerLogin, repositoryName)
+		rawURL = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/stack.yml", repositoryOwnerLogin, repositoryName, buildBranch())
 	case GitLab:
-		rawURL = fmt.Sprintf("%s/raw/master/stack.yml", repositoryURL)
+		rawURL = fmt.Sprintf("%s/raw/%s/stack.yml", repositoryURL, buildBranch())
 	}
 	if rawURL == "" {
 		return "", fmt.Errorf(`failed to find stack.yml file: cannot form proper raw URL.
@@ -359,4 +359,12 @@ func hasDockerfileFunction(functions map[string]stack.Function) bool {
 		}
 	}
 	return false
+}
+
+func buildBranch() string {
+	branch := os.Getenv("build_branch")
+	if branch == "" {
+		return "master"
+	}
+	return branch
 }

--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -113,7 +113,6 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 			return nil, configErr
 		}
 
-		// fmt.Println("Base: ", base, filePath, k)
 		err = filepath.Walk(base, func(path string, f os.FileInfo, pathErr error) error {
 			if pathErr != nil {
 				return pathErr
@@ -136,14 +135,12 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 			}
 
 			header.Name = strings.TrimPrefix(path, base)
-			// log.Printf("header.Name '%s'\n", header.Name)
 			if header.Name != "/config" {
 				header.Name = filepath.Join("context", header.Name)
 			}
 
 			header.Name = strings.TrimPrefix(header.Name, "/")
 
-			// log.Println("tar - header.Name ", header.Name)
 			if err1 = tarWriter.WriteHeader(header); err != nil {
 				return err1
 			}
@@ -180,7 +177,7 @@ func formatImageShaTag(registry string, function *stack.Function, sha string, ow
 
 	sha = sdk.FormatShortSHA(sha)
 
-	imageName = schema.BuildImageName(schema.SHAFormat, imageName, sha, "master")
+	imageName = schema.BuildImageName(schema.BranchAndSHAFormat, imageName, sha, buildBranch())
 
 	var imageRef string
 	sharedRepo := strings.HasSuffix(registry, "/")
@@ -343,8 +340,6 @@ func deploy(tars []tarEntry, pushEvent sdk.PushEvent, stack *stack.Services, sta
 		if statusErr != nil {
 			log.Printf(statusErr.Error())
 		}
-
-		// log.Printf(status.AuthToken)
 
 		fileOpen, err := os.Open(tarEntry.fileName)
 

--- a/github-push/handler.go
+++ b/github-push/handler.go
@@ -67,8 +67,8 @@ func Handle(req []byte) string {
 	status := sdk.BuildStatus(eventInfo, sdk.EmptyAuthToken)
 
 	if len(pushEvent.Ref) == 0 ||
-		pushEvent.Ref != "refs/heads/master" {
-		msg := "refusing to build non-master branch: " + pushEvent.Ref
+		pushEvent.Ref != fmt.Sprintf("refs/heads/%s", buildBranch()) {
+		msg := "refusing to build branch: " + pushEvent.Ref
 		auditEvent := sdk.AuditEvent{
 			Message: msg,
 			Owner:   pushEvent.Repository.Owner.Login,
@@ -166,4 +166,12 @@ func reportGitHubStatus(status *sdk.Status) {
 	if reportErr != nil {
 		log.Printf("failed to report status, error: %s", reportErr.Error())
 	}
+}
+
+func buildBranch() string {
+	branch := os.Getenv("build_branch")
+	if branch == "" {
+		return "master"
+	}
+	return branch
 }

--- a/github-push/handler.go
+++ b/github-push/handler.go
@@ -66,9 +66,9 @@ func Handle(req []byte) string {
 	eventInfo := sdk.BuildEventFromPushEvent(pushEvent)
 	status := sdk.BuildStatus(eventInfo, sdk.EmptyAuthToken)
 
-	if len(pushEvent.Ref) == 0 ||
-		pushEvent.Ref != fmt.Sprintf("refs/heads/%s", buildBranch()) {
-		msg := "refusing to build branch: " + pushEvent.Ref
+	if buildBranch := buildBranch(); len(pushEvent.Ref) == 0 ||
+		pushEvent.Ref != fmt.Sprintf("refs/heads/%s", buildBranch) {
+		msg := fmt.Sprintf("refusing to build target branch: %s, want branch: %s", pushEvent.Ref, buildBranch)
 		auditEvent := sdk.AuditEvent{
 			Message: msg,
 			Owner:   pushEvent.Repository.Owner.Login,

--- a/github-push/handler_test.go
+++ b/github-push/handler_test.go
@@ -27,7 +27,7 @@ func Test_Handle_Push_InvalidBranch(t *testing.T) {
 		`{"ref":"refs/heads/staging"}`,
 	))
 
-	want := "refusing to build non-master branch: refs/heads/staging"
+	want := "refusing to build branch: refs/heads/staging"
 	if res != want {
 		t.Errorf("want error: \"%s\", got: \"%s\"", want, res)
 		t.Fail()

--- a/github-push/handler_test.go
+++ b/github-push/handler_test.go
@@ -27,7 +27,7 @@ func Test_Handle_Push_InvalidBranch(t *testing.T) {
 		`{"ref":"refs/heads/staging"}`,
 	))
 
-	want := "refusing to build branch: refs/heads/staging"
+	want := "refusing to build target branch: refs/heads/staging, want branch: master"
 	if res != want {
 		t.Errorf("want error: \"%s\", got: \"%s\"", want, res)
 		t.Fail()


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
In order to provide a more CI/CD like experience for the users we decided to add an environment variable called `build_branch` that will have the branch that the users want to use for building their functions.
This PR changes the following functions:
* `buildshiprun`: I added a label for the deployment of each function: `com.openfaas.cloud.git-branch`. This label will have the branch that was used to deploy that function.
* `of-cloud-dashboard`: Add the git-branch to the response when calling `list-functions`. We then use that branch to show the link for the projects commits in the functions table.
* `git-tar`: I changed the format of the image name to include the branch that is being built. An example image name with this change: `matipan/matipan-faas-demo-slack-faces-result:latest-develop-cde0fb9`
* `github-push`: we used to validate that the branch trying to be built was only master. I changed it to check that the branch trying to be built is the one specified in `build_branch`. If `build_branch` is empty then we default to "master"

**Possible improvement**: add a `BuildBranch` function to the SDK package so that we don't have to replicate the same `buildBranch` func on each handler.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To test this I deployed the following functions on my own ofc installation:

* `matipan/buildshiprun:buildBranch`
* `matipan/of-git-tar:buildBranch`
* `matipan/github-push:buildBranch`
* `matipan/system-dashboard:buildBranch`

And set the `build_branch` to be `develop` for all deployments. [Here](https://github.com/matipan/faas-demo/commits/develop) you can see that ofc successfully built and deployed the functions using the develop branch.

The changes made to the dashboard and the image name can be seen here:
![dashboard](https://user-images.githubusercontent.com/8126891/56624891-27d10e00-6611-11e9-80ac-b8258fc78de4.png)
![imageName](https://user-images.githubusercontent.com/8126891/56624899-30294900-6611-11e9-86a4-5f76b5864d64.png)

And the new label that was added can be seen calling list functions:
![newLabel](https://user-images.githubusercontent.com/8126891/56624900-30294900-6611-11e9-8a36-5b8a10fcbd06.png)

## How are existing users impacted? What migration steps/scripts do we need?
They are not since this default to using `master` whenever the git-branch label or the build_branch env var is not set.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
