### PR TITLE
Bump git-tar version for template error change

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -47,7 +47,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.12.0
+    image: functions/of-git-tar:0.13.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -63,8 +63,8 @@ functions:
     secrets:
       - payload-secret
       - private-key
-# Uncomment this for GitLab
-#      - gitlab-api-token
+  # Uncomment this for GitLab
+  #      - gitlab-api-token
 
   buildshiprun:
     lang: go
@@ -88,7 +88,7 @@ functions:
       - basic-auth-user
       - basic-auth-password
       - payload-secret
-#      - swarm-pull-secret
+  #      - swarm-pull-secret
 
   garbage-collect:
     lang: go


### PR DESCRIPTION
Bumping git-tar image tag with the improved template
error due in separate PR as requested due to timing issues with
merging the change and doing a build

Signed-off-by: Martin Dekov <mdekov@vmware.com>

## Description

Bumping git-tar version for this PR as requested: #439 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A version bump

## How are existing users impacted? What migration steps/scripts do we need?

once built they will see that their tempate is missing

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
