### PR TITLE
Add network policies to limit ingress traffic

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -226,14 +226,12 @@ Create of-builder, of-buildkit:
 kubectl apply -f ./yaml/core
 ```
 
-(Optional) Deploy NetworkPolicy
+(Optional) Deploy NetworkPolicy. These policies set the following rules:
+* Pods in the `openfaas-fn` namespace only accept traffic from namespaces and pods that have the label `role: openfaas-system`
+* Pods in the `openfaas` namespace only accept traffic from all pods in namespaces with the label `role: openfaas-system`, pods that have the label `role: openfaas-system` in the `openfaas-fn` namespace and finally pods from any namespace that have the label `app: nginx-ingress`(this is to allow traffic from the nginx ingress controller).
+
 ```
 kubectl apply -f ./yaml/network-policy
-```
-
-(Optional) Add a role of "openfaas-system" using a label to the namespace where you deployed Ingress Controller. For example if Ingress Controller is deployed in the namespace `ingress-nginx`:
-```
-kubectl label namespace ingress-nginx role=openfaas-system
 ```
 
 If you don't have Ingress Controller installed in cluster. [Read this](#troubleshoot-network-policies)

--- a/yaml/network-policy/ns-openfaas-fn-net-policy.yml
+++ b/yaml/network-policy/ns-openfaas-fn-net-policy.yml
@@ -1,4 +1,3 @@
----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -9,11 +8,10 @@ spec:
     - Ingress
   podSelector: {}
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              role: openfaas-system
-
-        - podSelector:
-            matchLabels:
-              role: openfaas-system
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          role: openfaas-system
+    - podSelector:
+        matchLabels:
+          role: openfaas-system

--- a/yaml/network-policy/ns-openfaas-net-policy.yml
+++ b/yaml/network-policy/ns-openfaas-net-policy.yml
@@ -8,7 +8,17 @@ spec:
     - Ingress
   podSelector: {}
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              role: openfaas-system
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          role: openfaas-system
+    - namespaceSelector:
+        matchLabels:
+          role: openfaas-fn
+      podSelector:
+        matchLabels:
+          role: openfaas-system
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          app: nginx-ingress


### PR DESCRIPTION
This affects the namespaces `openfaas` and `openfaas-fn`.

Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
In order to add rules to who can access the pods on the `openfaas` and `openfaas-fn` namespaces the network policies were modified. The rules are as follows:
* Pods in the `openfaas-fn` namespace only accept traffic from namespaces and pods that have the label `role: openfaas-system`
* Pods in the `openfaas` namespace only accept traffic from all pods in namespaces with the label `role: openfaas-system`, pods that have the label `role: openfaas-system` in the `openfaas-fn` namespace and finally pods from any namespace that have the label `app: nginx-ingress`(this is to allow traffic from the nginx ingress controller).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed the network policies in my cluster and tried the following:
* Curl from a namespace that has no `role: openfaas-system` label to pods from `openfaas` and `openfaas-fn`, the connection timed-out since it never reached to the destination,
* Curl from the `openfaas` namespace to the `openfaas-fn` namespace and get a successful result,
* Curl from the `openfaas` namespace to other pods in the `openfaas` namespace and get a successful result,
* Curl from the `openfaas-fn` namespace to pods in the same namespace and get a successful result,
* Curl from the `openfaas-fn` namespace to pods in the `openfaas` namespace and get a successful result
* Call a function using the external domain and get a successful result(this means the network policy for the ingress is working)


## How are existing users impacted? What migration steps/scripts do we need?
They are affected only if they are using the network policies. If the are and they re-apply the policies everything should continue to work.
If they are not using the nginx ingress controller then the steps to follow are the same as they used to be.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
