### PR TITLE
Rewrite the host header to be the gateway's url

### DIFF
--- a/dashboard/of-cloud-dashboard/handler.js
+++ b/dashboard/of-cloud-dashboard/handler.js
@@ -47,12 +47,14 @@ module.exports = (event, context) => {
     const gatewayUrl = process.env.gateway_url.replace(/\/$/, '');
     const proxyPath = path.replace(/^\/api\//, '');
     const url = `${gatewayUrl}/function/${proxyPath}`;
+    var reqHeaders = event.headers;
+    reqHeaders['host'] = gatewayUrl.replace('http://', '');
     console.log(`proxying request to: ${url}`);
     request(
       {
         url,
         method,
-        headers: event.headers,
+        headers: reqHeaders,
         qs: event.query,
       },
       (err, response, body) => {


### PR DESCRIPTION
Signed-off-by: Matias Pan <matias.pan26@gmail.com>

## Description
This fixes an issue when injecting the linkerd2 proxy. The proxy
users the `host` http header as host for the request, if we don't
rewrite it to the gateway's host the request will come back to the
dashboard.

Fixes #460 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OFC installed on GKE. While I was injecting linkerd2 I noticed that the dashboard was not listing the user's functions. Once I made this change and deployed using the image `matipan/of-cloud-dashboard:debug` the dashboard could list the functions correctly.

## How are existing users impacted? What migration steps/scripts do we need?
They are impacted only if they are using linkerd2. If they are then they would need to upgrade their function to new release we create.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
