### PR TITLE
Whitelist the schedule annotation

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -211,6 +211,7 @@ func Handle(req []byte) string {
 
 		annotationWhitelist := []string{
 			"topic",
+			"schedule",
 		}
 		userAnnotations := buildAnnotations(annotationWhitelist, event.Annotations)
 		userAnnotations[sdk.FunctionLabelPrefix+"git-repo-url"] = event.RepoURL

--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -434,21 +434,35 @@ func Test_buildAnnotations_RemovesNonWhitelisted(t *testing.T) {
 }
 
 func Test_buildAnnotations_AllowsWhitelisted(t *testing.T) {
-	whitelist := []string{"topic"}
+	whitelist := []string{
+		"topic",
+		"schedule",
+	}
 
 	userValues := map[string]string{
-		"topic": "function.deployed",
+		"topic":    "function.deployed",
+		"schedule": "has schedule",
 	}
 
 	out := buildAnnotations(whitelist, userValues)
 
-	val, ok := out["topic"]
+	topicVal, ok := out["topic"]
 	if !ok {
 		t.Errorf("want user annotation: topic")
 		t.Fail()
 	}
-	if val != userValues["topic"] {
-		t.Errorf("want user annotation: topic - got %s, want %s", val, userValues["topic"])
+	if topicVal != userValues["topic"] {
+		t.Errorf("want user annotation: topic - got %s, want %s", topicVal, userValues["topic"])
+		t.Fail()
+	}
+
+	scheduleVal, ok := out["schedule"]
+	if !ok {
+		t.Errorf("want user annotation: schedule")
+		t.Fail()
+	}
+	if scheduleVal != userValues["schedule"] {
+		t.Errorf("want user annotation: schedule - got %s, want %s", scheduleVal, userValues["schedule"])
 		t.Fail()
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -582,6 +582,8 @@ Users can set the following custom annotations:
 
 * `topic` - the topic annotation is used with the event-connector pattern, if at least one event-connector is installed on the OFC installation.
 
+* `schedule` - the schedule annotation is used with the [cron-connector](https://github.com/zeerorg/cron-connector) function.
+
 ### Dashboard
 
 The Dashboard is optional and can be installed to visualise your functions.


### PR DESCRIPTION
Signed-off-by: Chris Kolenko <chris@webcanvas.com.au>

## Description
Add schedule annotation
Fixes #489

## How Has This Been Tested?
Only via test

## How are existing users impacted? What migration steps/scripts do we need?
Uses will need to upgrade buildshiprun to use this feature


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
