### PR TITLE
Fix conflict with "config" folder in functions

### DIFF
--- a/git-tar/function/ops.go
+++ b/git-tar/function/ops.go
@@ -27,6 +27,9 @@ import (
 	"github.com/openfaas/openfaas-cloud/sdk"
 )
 
+// ConfigFileName for Docker bundle
+const ConfigFileName = "com.openfaas.docker.config"
+
 type tarEntry struct {
 	fileName     string
 	functionName string
@@ -108,7 +111,7 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 		}
 
 		configBytes, _ := json.Marshal(config)
-		configErr := ioutil.WriteFile(path.Join(base, "config"), configBytes, 0600)
+		configErr := ioutil.WriteFile(path.Join(base, ConfigFileName), configBytes, 0600)
 		if configErr != nil {
 			return nil, configErr
 		}
@@ -135,7 +138,7 @@ func makeTar(pushEvent sdk.PushEvent, filePath string, services *stack.Services)
 			}
 
 			header.Name = strings.TrimPrefix(path, base)
-			if header.Name != "/config" {
+			if header.Name != fmt.Sprintf("/%s", ConfigFileName) {
 				header.Name = filepath.Join("context", header.Name)
 			}
 

--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -90,14 +90,16 @@ The builder service calls into the buildkit daemon to build an OpenFaaS function
 ### Build
 
 ```sh
-export OF_BUILDER_TAG=0.6.3
+export OF_BUILDER_TAG=0.7.0
+
 make build push
 ```
 
 ### Deploy
 
-```
-export OF_BUILDER_TAG=0.6.3
+```sh
+export OF_BUILDER_TAG=0.7.0
+
 docker service create \
  --network func_functions \
  --name of-builder \
@@ -122,7 +124,7 @@ rm -rf test-image && \
 mkdir -p test-image && \
 cd test-image
 
-echo '{"Ref": "registry.local:5000/foo/bar:latest"}' > config
+echo '{"Ref": "registry.local:5000/foo/bar:latest"}' > com.openfaas.docker.config
 
 mkdir -p context
 echo "## Made with buildkit" >> context/README.md
@@ -169,4 +171,3 @@ Test:
 docker rm -f dind; docker run --name dind --privileged --net=builder -d docker:dind dockerd --insecure-registry registry:5000
 docker exec -ti dind docker pull registry:5000/jmkhael/figlet:latest-99745ca9f5a1a914384686e0e928a10854cc87d5
 ```
-

--- a/of-builder/main.go
+++ b/of-builder/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -25,6 +26,9 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
+
+// ConfigFileName for Docker bundle
+const ConfigFileName = "com.openfaas.docker.config"
 
 var (
 	lchownEnabled bool
@@ -63,8 +67,11 @@ func main() {
 	router.HandleFunc("/build", buildHandler)
 	router.HandleFunc("/healthz", healthzHandler)
 
+	addr := "0.0.0.0:8080"
+	log.Printf("of-builder serving traffic on: %s\n", addr)
+
 	server := &http.Server{
-		Addr:    "0.0.0.0:8080",
+		Addr:    addr,
 		Handler: router,
 	}
 
@@ -142,7 +149,7 @@ func build(w http.ResponseWriter, r *http.Request, buildArgs map[string]string) 
 		return nil, err
 	}
 
-	dt, err := ioutil.ReadFile(filepath.Join(tmpdir, "config"))
+	dt, err := ioutil.ReadFile(filepath.Join(tmpdir, ConfigFileName))
 	if err != nil {
 		return nil, err
 	}

--- a/stack.yml
+++ b/stack.yml
@@ -47,7 +47,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.13.1
+    image: functions/of-git-tar:0.14.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

User functions may have a folder named "config" as part of their
code - i.e. laravel projects. This commit renames the config
file which was used for buildkit and uses a DNS-format to avoid
conflicts (suggested by @AkihiroSuda).

Fixes: #510

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Customer provided an example repo, which failed to build/deploy before the patch and passed after.

https://github.com/dxcn/incubator-ofc-example/blob/master/ping/Dockerfile

## How are existing users impacted? What migration steps/scripts do we need?

Users will need to upgrade if they experience the issue in #510 by updating the docker image for the of-builder and git-tar to latest. No other changes are required.

ofc-bootstrap should also vendor a new version of OpenFaaS Cloud
