### PR TITLE
Updated of-builder to 0.7.0 in yaml/core/of-builder-dep.yml

### DIFF
--- a/yaml/core/of-builder-dep.yml
+++ b/yaml/core/of-builder-dep.yml
@@ -21,7 +21,7 @@ spec:
             secretName: payload-secret
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.6.2
+        image: openfaas/of-builder:0.7.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Signed-off-by: santiago riveros <“santiago.riveros@gmail.com”>

## Description
Before running ofc-bootstrap ended up with of-builder 0.6.2 which has trouble with OFC 0.9.7+ due to config folder rename

## How Has This Been Tested?
I modified the ofc-bootstrap script clone-cloud-components.sh to clone my fork of OFC and of-builder is 0.7.0 after running. 

## How are existing users impacted? What migration steps/scripts do we need?
Existing users can upgrade with kubectl apply -f yaml/core/of-builder-dep.yml

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
