### PR TITLE
Lowercase username when managing secrets

### DIFF
--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -458,7 +458,7 @@ func getEventFromEnv() (*sdk.Event, error) {
 	info.Secrets = secretVars
 
 	for i := 0; i < len(info.Secrets); i++ {
-		info.Secrets[i] = info.Owner + "-" + info.Secrets[i]
+		info.Secrets[i] = strings.ToLower(info.Owner) + "-" + info.Secrets[i]
 	}
 
 	log.Printf("%d env-vars for %s", len(info.Environment), info.Service)

--- a/buildshiprun/handler.go
+++ b/buildshiprun/handler.go
@@ -457,8 +457,9 @@ func getEventFromEnv() (*sdk.Event, error) {
 
 	info.Secrets = secretVars
 
+	owner := strings.ToLower(info.Owner)
 	for i := 0; i < len(info.Secrets); i++ {
-		info.Secrets[i] = strings.ToLower(info.Owner) + "-" + info.Secrets[i]
+		info.Secrets[i] = owner + "-" + info.Secrets[i]
 	}
 
 	log.Printf("%d env-vars for %s", len(info.Environment), info.Service)

--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -67,7 +67,7 @@ func Handle(req []byte) string {
 		return fmt.Sprintf("invalid owner name %s", event.owner)
 	}
 
-	name := strings.ToLower(fmt.Sprintf("%s", userSecret.Metadata.Name))
+	name := strings.ToLower(userSecret.Metadata.Name)
 
 	if strings.HasPrefix(name, strings.ToLower(event.owner)) == false {
 		return fmt.Errorf("unable to bind a secret which does not start with owner name: %s", event.owner).Error()

--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -68,9 +68,10 @@ func Handle(req []byte) string {
 	}
 
 	name := strings.ToLower(userSecret.Metadata.Name)
+	ownerNormalized := strings.ToLower(event.owner)
 
-	if strings.HasPrefix(name, strings.ToLower(event.owner)) == false {
-		return fmt.Errorf("unable to bind a secret which does not start with owner name: %s", event.owner).Error()
+	if !strings.HasPrefix(name, ownerNormalized) {
+		return fmt.Errorf("unable to bind a secret which does not start with owner name: %s", ownerNormalized).Error()
 	}
 
 	existingSS, err := ssc.SealedSecrets(userSecret.Metadata.Namespace).Get(name, metav1.GetOptions{})

--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -67,11 +67,11 @@ func Handle(req []byte) string {
 		return fmt.Sprintf("invalid owner name %s", event.owner)
 	}
 
-	if strings.HasPrefix(userSecret.Metadata.Name, event.owner) == false {
+	name := strings.ToLower(fmt.Sprintf("%s", userSecret.Metadata.Name))
+
+	if strings.HasPrefix(name, strings.ToLower(event.owner)) == false {
 		return fmt.Errorf("unable to bind a secret which does not start with owner name: %s", event.owner).Error()
 	}
-
-	name := fmt.Sprintf("%s", userSecret.Metadata.Name)
 
 	existingSS, err := ssc.SealedSecrets(userSecret.Metadata.Namespace).Get(name, metav1.GetOptions{})
 


### PR DESCRIPTION
Signed-off-by: Jonatas Baldin <jonatas.baldin@gmail.com>

## Description
Lower case the username when managing secrets. Fixes #502.

Will still add documentation about creating the sealed secret just in lowercase, even if the GitHub username is uppercase.

## How Has This Been Tested?
- Using a GitHub user account with an uppercase character
- Create a sealed secret in lowercase
- Push the project and it builds correctly
- Tests made [here](https://github.com/Uppercase-username/ofc-test/runs/266808847)

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
