### PR TITLE
Only allow a user access to pages they have explicit Oauth claims for

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -22,3 +22,5 @@ of-cloud-dashboard/dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+of-cloud-dashboard/dist/
+dashboard/of-cloud-dashboard/dist/

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -19,7 +19,7 @@ The Dashboard is a SPA(Single Page App) made with React and will require the fol
 This may be simpler than deploying the builder and connecting your OpenFaaS Cloud to a GitHub App.
 
 ```
-$ faas-cli store deploy figlet --name alexellis-figlet --label Git-Owner=alexellis \
+$ faas-cli store deploy figlet --name alexellis-figlet --label com.openfaas.cloud.git-owner=alexellis \
  --label com.openfaas.cloud.git-repo=figlet \
  --label com.openfaas.cloud.git-sha=665d9597547d8e0425630ba2dbb73c2951a61ce2 \
  --label com.openfaas.cloud.git-deploytime=1533026741 \

--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -17,7 +17,6 @@
     window.PUBLIC_URL = '__PUBLIC_URL__';
     window.PRETTY_URL = '__PRETTY_URL__';
     window.QUERY_PRETTY_URL = '__QUERY_PRETTY_URL__';
-    window.ORGANIZATIONS = '__ORGANIZATIONS__';
   </script>
 </head>
 

--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -17,6 +17,7 @@
     window.PUBLIC_URL = '__PUBLIC_URL__';
     window.PRETTY_URL = '__PRETTY_URL__';
     window.QUERY_PRETTY_URL = '__QUERY_PRETTY_URL__';
+    window.ORGANIZATIONS = '__ORGANIZATIONS__';
   </script>
 </head>
 

--- a/dashboard/client/src/App.css
+++ b/dashboard/client/src/App.css
@@ -118,8 +118,13 @@ a {
     background-color: #dff0d8 !important;
 }
 
+
 .color-success {
     color: #3c763d !important;
+}
+
+.color-failure {
+    color: red;
 }
 
 .color-white {

--- a/dashboard/client/src/App.js
+++ b/dashboard/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import {BrowserRouter, Route, Switch} from 'react-router-dom';
 
 import { NavBar } from './components/NavBar';
 import { FunctionsOverviewPage } from './pages/FunctionsOverviewPage';
@@ -35,7 +35,7 @@ export class App extends Component {
                 path="/:user/:functionName/log"
                 component={FunctionLogPage}
               />
-              <Route component={NotFoundPage} />
+              return  <Route component={NotFoundPage} />
             </Switch>
           </div>
           <Footer />
@@ -44,3 +44,4 @@ export class App extends Component {
     );
   }
 }
+

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -95,7 +95,22 @@ class FunctionsApi {
     });
   }
 
-  fetchFunctions(user) {
+  fetchFunctions(user, organizations) {
+    var orgs = [];
+    orgs.push(user);
+    if (organizations) {
+      orgs = orgs.concat(organizations.split(',')).filter(item => item);
+    }
+
+    var fetchPromises = [];
+    orgs.forEach((org)=> {
+      fetchPromises.push(this.fetchFunctionsByUser(org));
+    });
+
+    return Promise.all(fetchPromises);
+  }
+
+  fetchFunctionsByUser(user) {
     const url = `${this.apiBaseUrl}/list-functions?user=${user}`;
     return axios
       .get(url)

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -98,9 +98,12 @@ class FunctionsApi {
   fetchFunctions(user, organizations) {
     var orgs = [];
     orgs.push(user);
-    if (organizations) {
-      orgs = orgs.concat(organizations.split(',')).filter(item => item);
-    }
+
+    // When we want to get the functions a user is able to see through being a member of an org, uncomment this.
+    // This needs to be a unique set - as we add the "user" above, which might be the org
+    // if (organizations) {
+    //   orgs = orgs.concat(organizations.split(',')).filter(item => item);
+    // }
 
     var fetchPromises = [];
     orgs.forEach((org)=> {

--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -86,5 +86,5 @@ const FunctionTableItem = ({ onClick, fn, user }) => {
 };
 
 export {
-  FunctionTableItem
+    FunctionTableItem
 };

--- a/dashboard/client/src/pages/FunctionsOverviewPage.jsx
+++ b/dashboard/client/src/pages/FunctionsOverviewPage.jsx
@@ -24,8 +24,20 @@ export class FunctionsOverviewPage extends Component {
   componentDidMount() {
     this.setState({ isLoading: true });
 
-    functionsApi.fetchFunctions(this.state.user).then(res => {
-      this.setState({ isLoading: false, fns: res });
+
+    functionsApi.fetchFunctions(this.state.user, window.ORGANIZATIONS)
+    .then(res => {
+      let functions = [];
+      res.forEach( (set) => {
+        set.forEach(  (item) => {
+          functions.push(item);
+        });
+      });
+
+      this.setState({ isLoading: false, fns: functions });
+    })
+    .catch((e) => {
+      console.error(e);
     });
   }
 

--- a/dashboard/client/src/pages/FunctionsOverviewPage.jsx
+++ b/dashboard/client/src/pages/FunctionsOverviewPage.jsx
@@ -8,6 +8,8 @@ import {
   CardBody,
   CardText,
 } from 'reactstrap';
+import {faExclamationTriangle} from "@fortawesome/free-solid-svg-icons";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 export class FunctionsOverviewPage extends Component {
   constructor(props) {
@@ -17,6 +19,7 @@ export class FunctionsOverviewPage extends Component {
     this.state = {
       isLoading: true,
       fns: [],
+      authError: false,
       user,
     };
   }
@@ -29,7 +32,7 @@ export class FunctionsOverviewPage extends Component {
     .then(res => {
       let functions = [];
       res.forEach( (set) => {
-        set.forEach(  (item) => {
+        set.forEach((item) => {
           functions.push(item);
         });
       });
@@ -37,12 +40,26 @@ export class FunctionsOverviewPage extends Component {
       this.setState({ isLoading: false, fns: functions });
     })
     .catch((e) => {
-      console.error(e);
+      if (e.response.status === 403) {
+        this.setState({isLoading: false, fns: [], authError: true})
+      } else {
+        console.error(e);
+      }
     });
   }
 
   renderContentView() {
-    const { user, isLoading, fns } = this.state;
+    const { user, isLoading, fns, authError } = this.state;
+
+    if (!isLoading && authError) {
+      return (
+          <Card>
+            <CardHeader className="color-failure">
+              <FontAwesomeIcon icon={faExclamationTriangle} /> Error: You do not have valid permissions for <span id="username">{ user }</span>
+            </CardHeader>
+          </Card>
+      )
+    }
 
     if (!isLoading && fns.length === 0) {
       return (

--- a/dashboard/of-cloud-dashboard/handler.js
+++ b/dashboard/of-cloud-dashboard/handler.js
@@ -33,6 +33,10 @@ const handleLogout = (context) => {
 module.exports = (event, context) => {
   const { method, path } = event;
 
+  parseOrganizations: parseOrganizations;
+  decodeCookie: decodeCookie;
+  getCookie: getCookie;
+
   if (method !== 'GET') {
     context.status(400).fail('Bad Request');
     return;
@@ -111,12 +115,17 @@ module.exports = (event, context) => {
 
       const isSignedIn = /openfaas_cloud_token=.*\s*/.test(event.headers.cookie);
 
+      let cookie = getCookie(event);
+      let organizations = parseOrganizations(cookie);
+
       const { base_href, public_url, pretty_url, query_pretty_url } = process.env;
       content = content.replace(/__BASE_HREF__/g, base_href);
       content = content.replace(/__PUBLIC_URL__/g, public_url);
       content = content.replace(/__PRETTY_URL__/g, pretty_url);
       content = content.replace(/__QUERY_PRETTY_URL__/g, query_pretty_url);
       content = content.replace(/__IS_SIGNED_IN__/g, isSignedIn);
+      content = content.replace(/__ORGANIZATIONS__/g, organizations);
+
     }
 
     context
@@ -125,3 +134,32 @@ module.exports = (event, context) => {
       .succeed(content);
   });
 };
+
+var parseOrganizations = function (cookie) {
+  var decodedCookie = decodeCookie(cookie);
+  console.log("decodedCookie -> ", decodedCookie);
+  if (decodedCookie && 'organizations' in decodedCookie) {
+    return decodedCookie.organizations;
+  }
+  return '';
+}
+
+var atob = function atob(str) {
+  return Buffer.from(str, 'base64').toString('binary');
+}
+
+var decodeCookie = function (token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch (e) {
+    return null;
+  }
+}
+
+var getCookie = function (event = {}) {
+  if (!event.headers && !event.headers.cookie) {
+    console.log("event does not contain a cookie");
+    return null;
+  }
+  return event.headers.cookie;
+}

--- a/edge-auth/README.md
+++ b/edge-auth/README.md
@@ -29,6 +29,7 @@ Contents (encoded JWT):
 {
   "name": "Alex Ellis",
   "access_token": "token-value",
+  "organizations": "som-org",
   "aud": ".system.gw.io",
   "exp": 1537957152,
   "jti": "integer-value-here",
@@ -37,6 +38,9 @@ Contents (encoded JWT):
   "sub": "alexellis"
 }
 ```
+
+Please note - You need to be a public member of any Organisation that you wish to be able to see the dashboard and functions for.
+
 
 ## Building
 

--- a/edge-router/main.go
+++ b/edge-router/main.go
@@ -88,6 +88,22 @@ func makeHandler(c *http.Client, timeout time.Duration, upstreamURL string, auth
 		requestURI = strings.TrimLeft(requestURI, "/")
 
 		if len(requestURI) == 0 {
+			if host == "system" {
+				scheme := "http"
+				if r.TLS != nil {
+					scheme = "https"
+				}
+				redirectUrl, urlErr := url.Parse(fmt.Sprintf("%s://%s/dashboard/", scheme, r.Host))
+
+				if urlErr != nil {
+					http.Error(w, urlErr.Error(), http.StatusInternalServerError)
+					log.Printf("Could not build dashboard redirect url %s", urlErr.Error())
+					return
+				}
+				log.Printf("Redirecting to %q\n", redirectUrl.String())
+				http.Redirect(w, r, redirectUrl.String(), http.StatusTemporaryRedirect)
+				return
+			}
 			log.Printf("requestURI not set\n")
 			w.WriteHeader(http.StatusNotFound)
 			return


### PR DESCRIPTION
## Description

A user can now only access pages they have the claims to view, so their own and any organisations that they are a public member of.
(screenshot for not authorised)
![image](https://user-images.githubusercontent.com/40488132/68165188-ab6f9e00-ff56-11e9-8f5e-191f3fd81e91.png)


A user navigating to `/`, `/dashboard` or `/dashboard/` will be redirected to their `/dashboard/{{username}}` page when they are authenticated.



Closes #289 
Closes #353 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. A user who is authd goes to their page -> success 
2. A user who is authd goes to an organisation page that they belong to -> success
3. A user navigates to a page they are not allowed to see --> Page displaying this error shown (screenshot above)
4. A user who is not authd gets no information -> Gets oauth login page for app
5. A user who navigates to root url (or /dashboard, or /dashboard/) gets redirected to /dashboard/{{user}} --> succsess
6. A user who is not authd goes to root url (or /dashboard, or /dashboard/) gets redirected to oath page, and when they signin gets redirected to thier user page (/dashboard/{{user}})



## How are existing users impacted? What migration steps/scripts do we need?
N/A


## Checklist:

I have:

- [] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
