### PR TITLE
Fix regression in Dashboard auth. Add user to Api Requests

### DIFF
--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -154,7 +154,7 @@ class FunctionsApi {
       timePeriod
     } = params;
     try {
-      const url = `${this.apiBaseUrl}/system-metrics?function=${user.toLowerCase()}-${functionName}&metrics_window=${timePeriod}`;
+      const url = `${this.apiBaseUrl}/system-metrics?function=${user.toLowerCase()}-${functionName}&metrics_window=${timePeriod}&user=${user}`;
       const result = await axios
         .get(url);
       return result.data;
@@ -167,11 +167,12 @@ class FunctionsApi {
   fetchFunctionLog({
     commitSHA,
     repoPath,
-    functionName
+    functionName,
+    user
   }) {
     const url = `${
       this.apiBaseUrl
-    }/pipeline-log?commitSHA=${commitSHA}&repoPath=${repoPath}&function=${functionName}`;
+    }/pipeline-log?commitSHA=${commitSHA}&repoPath=${repoPath}&function=${functionName}&user=${user}`;
     return axios.get(url).then(res => {
       return res.data;
     });

--- a/dashboard/client/src/pages/FunctionLogPage.jsx
+++ b/dashboard/client/src/pages/FunctionLogPage.jsx
@@ -18,7 +18,7 @@ export class FunctionLogPage extends Component {
   constructor(props) {
     super(props);
     const { commitSHA, repoPath } = queryString.parse(props.location.search);
-    const { functionName } = props.match.params;
+    const { functionName, user} = props.match.params;
 
     this.state = {
       isLoading: true,
@@ -26,15 +26,16 @@ export class FunctionLogPage extends Component {
       commitSHA,
       repoPath,
       functionName,
+      user
     };
   }
 
   componentDidMount() {
-    const { commitSHA, repoPath, functionName } = this.state;
+    const { commitSHA, repoPath, functionName, user } = this.state;
 
     this.setState({ isLoading: true });
 
-    functionsApi.fetchFunctionLog({ commitSHA, repoPath, functionName }).then(res => {
+    functionsApi.fetchFunctionLog({ commitSHA, repoPath, functionName, user }).then(res => {
       this.setState({ isLoading: false, log: res });
     });
   }


### PR DESCRIPTION
## Description

Previously only the list-functions api had the user sent back
as a query parameter. This has been added to the other /api/
endpoints so they now auth correctly and dont get a 403.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Screenshots from own OFC dashboard, now the logs and invocation details are fetched.

<img width="1369" alt="Screenshot 2019-11-05 at 22 07 16" src="https://user-images.githubusercontent.com/40488132/68250478-e934fb00-0018-11ea-9e30-3452cc08fd37.png">
<img width="472" alt="Screenshot 2019-11-05 at 22 02 36" src="https://user-images.githubusercontent.com/40488132/68250479-e934fb00-0018-11ea-894b-3bd36e7d0f7a.png">


## How are existing users impacted? What migration steps/scripts do we need?
Fix regression. 


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
