### PR TITLE
Add restricted status to pipeline functions

### DIFF
--- a/edge-auth/README.md
+++ b/edge-auth/README.md
@@ -45,7 +45,7 @@ Please note - You need to be a public member of any Organisation that you wish t
 ## Building
 
 ```
-export TAG=0.5.3
+export TAG=0.6.2
 make build push
 ```
 
@@ -53,6 +53,8 @@ make build push
 
 All environmental variables must be set and configured for the service whether running locally as a container, via Swarm or on Kubernetes.
 
+* `/system-dashboard` and `/system-metrics` are protected by OAuth
+* All pipeline functions in OpenFaaS Cloud's stack.yml are blocked by default from all ingress such as `git-tar` and `buildshiprun`
 
 ### Generate a key/pair
 
@@ -104,7 +106,7 @@ echo -n "$CLIENT_SECRET" | docker secret create of-client-secret -
 
 ```sh
 docker rm -f edge-auth
-export TAG=0.5.2
+export TAG=0.6.2
 
 docker run \
  -e client_secret="$CLIENT_SECRET" \
@@ -128,7 +130,7 @@ Edit `yaml/core/edge-auth-dep.yml` as needed and apply that file.
 ### On Swarm:
 
 ```sh
-export TAG=0.5.2
+export TAG=0.6.2
 docker service rm edge-auth
 docker service create --name edge-auth \
  -e oauth_client_secret_path="/run/secrets/of-client-secret" \

--- a/edge-auth/handlers/query.go
+++ b/edge-auth/handlers/query.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MakeQueryHandler returns whether a client can access a resource
-func MakeQueryHandler(config *Config, protected []string) func(http.ResponseWriter, *http.Request) {
+func MakeQueryHandler(config *Config, protected []string, restrictedPrefix []string) func(http.ResponseWriter, *http.Request) {
 	keydata, err := ioutil.ReadFile(config.PublicKeyPath)
 	if err != nil {
 		log.Fatalf("unable to read path: %s, error: %s", config.PublicKeyPath, err.Error())
@@ -35,6 +35,8 @@ func MakeQueryHandler(config *Config, protected []string) func(http.ResponseWrit
 		status := http.StatusOK
 		if len(resource) == 0 {
 			status = http.StatusBadRequest
+		} else if isProtected(resource, restrictedPrefix) {
+			status = http.StatusUnauthorized
 		} else if isProtected(resource, protected) {
 			started := time.Now()
 			cookieStatus := validCookie(r, cookieName, publicKey, customers, config.Debug)

--- a/edge-auth/main.go
+++ b/edge-auth/main.go
@@ -96,8 +96,30 @@ func main() {
 
 	protected := []string{
 		"/function/system-dashboard",
-		"/function/system-list-functions",
-		"/function/system-metrics",
+	}
+
+	// Functions which make up the pipeline and which should not
+	// be exposed via public ingress.
+	restrictedPrefix := []string{
+		"/function/ofc-",
+		"/function/github-push",
+		"/function/git-tar",
+		"/function/buildshiprun",
+		"/function/garbage-collect",
+		"/function/github-status",
+		"/function/import-secrets",
+		"/function/pipeline-log",
+		"/function/list-functions",
+		"/function/audit-event",
+		"/function/echo",
+		"/function/metrics",
+
+		//AWS
+		"/function/register-image",
+
+		// GitLab
+		"/function/gitlab-status",
+		"/function/gitlab-push",
 	}
 
 	fs := http.FileServer(http.Dir("static"))
@@ -107,7 +129,7 @@ func main() {
 
 	router.HandleFunc("/", handlers.MakeHomepageHandler(config))
 
-	router.HandleFunc("/q/", handlers.MakeQueryHandler(config, protected))
+	router.HandleFunc("/q/", handlers.MakeQueryHandler(config, protected, restrictedPrefix))
 	router.HandleFunc("/login/", handlers.MakeLoginHandler(config))
 	router.HandleFunc("/oauth2/", handlers.MakeOAuth2Handler(config))
 	router.HandleFunc("/healthz/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Add restricted status to pipeline functions

Functions which make up the pipeline are now being restricted
from public ingress. This has been tested with the audit-event
function, which was previously publicly accessible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The Community Cluster has been patched already.

## How are existing users impacted? What migration steps/scripts do we need?

Existing users are encouraged to update their `edge-auth` deployment to take the new version: `0.6.2`

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
