### PR TITLE
Update the log dashboard to pull 30 mins of logs

### DIFF
--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -6,7 +6,7 @@ import { faUserSecret } from "@fortawesome/free-solid-svg-icons";
 import { ReplicasProgress } from "../ReplicasProgress";
 
 const genLogPath = ({ shortName, gitOwner, gitRepo, gitSha }, user) => (
-  `${user}/${shortName}/log?repoPath=${gitOwner}/${gitRepo}&commitSHA=${gitSha}`
+  `${user}/${shortName}/build-log?repoPath=${gitOwner}/${gitRepo}&commitSHA=${gitSha}`
 );
 
 const genFnDetailPath = ({ shortName, gitOwner, gitRepo }, user) => (

--- a/dashboard/client/src/pages/FunctionLogPage.jsx
+++ b/dashboard/client/src/pages/FunctionLogPage.jsx
@@ -87,10 +87,10 @@ export class FunctionLogPage extends Component {
 
       try {
           functionsApi.fetchFunctionLog({longFnName, user}).then(res => {
-              this.setState({log: res});
+              this.setState({log: res, isLoading: false});
           })
       } catch (e) {
-          this.setState({fetchError: e})
+          this.setState({fetchError: e, isLoading: false})
       }
     }
 

--- a/function-logs/handler.go
+++ b/function-logs/handler.go
@@ -64,6 +64,7 @@ func getFormattedLogs(gatewayURL string, function string) (string, error) {
 
 	queryParams["name"] = function
 	queryParams["follow"] = "false"
+	queryParams["since"] = time.Now().Add(-1 * time.Minute * 30).Format(time.RFC3339)
 
 	response, bodyBytes := makeGatewayHttpReq(gatewayURL+"/system/logs", queryParams)
 


### PR DESCRIPTION
# Description

The initial implementation had a 5 min max on fetching logs.
This has been upped to 30 mins, and indicated on the dashboard

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
deployed onto my ofc, ran went to the logs page, it returned 30mins of logs rather than 5min

## How are existing users impacted? What migration steps/scripts do we need?
new deploy of dashboard and function-logs (release version containers need bumping)


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
