### PR TITLE
Change dashboard logs button to point at runtime logs and remove extra function

### DIFF
--- a/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
+++ b/dashboard/client/src/components/FunctionTableItem/FunctionTableItem.jsx
@@ -6,7 +6,7 @@ import { faUserSecret } from "@fortawesome/free-solid-svg-icons";
 import { ReplicasProgress } from "../ReplicasProgress";
 
 const genLogPath = ({ shortName, gitOwner, gitRepo, gitSha }, user) => (
-  `${user}/${shortName}/build-log?repoPath=${gitOwner}/${gitRepo}&commitSHA=${gitSha}`
+  `${user}/${shortName}/function-log?repoPath=${gitOwner}/${gitRepo}&commitSHA=${gitSha}`
 );
 
 const genFnDetailPath = ({ shortName, gitOwner, gitRepo }, user) => (

--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -13,22 +13,6 @@ functions:
     environment_file:
       - dashboard_config.yml
 
-  system-list-functions:
-    skip_build: true
-    image: functions/list-functions:0.5.0
-    fprocess: ./handler
-    labels:
-      openfaas-cloud: "1"
-      role: openfaas-system
-    environment:
-      gateway_url: http://gateway.openfaas:8080/
-      secret_mount_path: /var/openfaas/secrets
-      basic_auth: true
-      write_debug: true
-    secrets:
-      - basic-auth-user
-      - basic-auth-password
-
 configuration:
   templates:
     - name: node10-express


### PR DESCRIPTION
## Description

The logs button on the functions-overview page should point
at the runtime logs rather than build time. They now do
Also removed an extra function, system-list-functions
as the list-functions is the same image, and it's blocked
for public invocation by edge-auth

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed the new dashboard to my OFC instance and navigated using that new link to runtime logs.

Also deleted the deployment of system-list-functions and application works as expected. There are no references to this function in the rest of the codebase so it was extra.
The list-functions route was already explicitly blacklisted from edge-auth. (no public ingress to that function)

## How are existing users impacted? What migration steps/scripts do we need?
New deploy of dashboard needed, and deletion of the system-list-functions deployment if it exists.

I would like this release cut so i can update ofc-bootstrap to the latest version so users of that tool get the new logs functionality.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
