### PR TITLE
Add Dropdown to Function List page

### DIFF
--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -17,6 +17,7 @@
     window.PUBLIC_URL = '__PUBLIC_URL__';
     window.PRETTY_URL = '__PRETTY_URL__';
     window.QUERY_PRETTY_URL = '__QUERY_PRETTY_URL__';
+    window.ALL_CLAIMS = '__ALL_CLAIMS__'
   </script>
 </head>
 

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -95,8 +95,10 @@ class FunctionsApi {
     });
   }
 
-  fetchFunctions(user, organizations) {
-    var orgs = [];
+  fetchFunctions(user) {
+
+    let all_claims = window.ALL_CLAIMS; // TOOD when we implement dashboards with all fns, set this to the list of pulled
+    let orgs = [];
     orgs.push(user);
 
     // When we want to get the functions a user is able to see through being a member of an org, uncomment this.
@@ -105,7 +107,7 @@ class FunctionsApi {
     //   orgs = orgs.concat(organizations.split(',')).filter(item => item);
     // }
 
-    var fetchPromises = [];
+    let fetchPromises = [];
     orgs.forEach((org)=> {
       fetchPromises.push(this.fetchFunctionsByUser(org));
     });

--- a/dashboard/client/src/components/Dropdown/DashboardDropDownLinks.jsx
+++ b/dashboard/client/src/components/Dropdown/DashboardDropDownLinks.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { Dropdown, DropdownToggle, DropdownMenu, DropdownItem } from 'reactstrap';
+
+const DashboardDropDownLinks = (props) => {
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const {linkBuilder, linkList, currentUser} = props;
+
+    const toggle = () => setDropdownOpen(prevState => !prevState);
+
+    const claims = linkList.split(",")
+
+    return (
+        <Dropdown isOpen={dropdownOpen} toggle={toggle}>
+            <DropdownToggle caret>
+                Functions for {currentUser}
+            </DropdownToggle>
+            <DropdownMenu>
+                {
+                    claims.map((value) => {
+                        if (value === currentUser) {return }
+                        return <DropdownItem href={linkBuilder(value)}>Functions for {value}</DropdownItem>
+                    })
+                }
+            </DropdownMenu>
+        </Dropdown>
+    );
+}
+
+export { DashboardDropDownLinks };

--- a/dashboard/client/src/components/Dropdown/index.js
+++ b/dashboard/client/src/components/Dropdown/index.js
@@ -1,0 +1,1 @@
+export * from './DashboardDropDownLinks';

--- a/dashboard/client/src/pages/FunctionsOverviewPage.jsx
+++ b/dashboard/client/src/pages/FunctionsOverviewPage.jsx
@@ -10,6 +10,7 @@ import {
 } from 'reactstrap';
 import {faExclamationTriangle} from "@fortawesome/free-solid-svg-icons";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {DashboardDropDownLinks} from "../components/Dropdown";
 
 export class FunctionsOverviewPage extends Component {
   constructor(props) {
@@ -28,7 +29,7 @@ export class FunctionsOverviewPage extends Component {
     this.setState({ isLoading: true });
 
 
-    functionsApi.fetchFunctions(this.state.user, window.ORGANIZATIONS)
+    functionsApi.fetchFunctions(this.state.user)
     .then(res => {
       let functions = [];
       res.forEach( (set) => {
@@ -46,6 +47,10 @@ export class FunctionsOverviewPage extends Component {
         console.error(e);
       }
     });
+  }
+
+  linkBuilder(location) {
+      return `/dashboard/${location}`
   }
 
   renderContentView() {
@@ -83,7 +88,7 @@ export class FunctionsOverviewPage extends Component {
     return (
       <Card outline color="success">
         <CardHeader className="bg-success color-success">
-          Functions for <span id="username">{ user }</span>
+              {window.ALL_CLAIMS === "" ? (`Functions for ${user}`) :  (<DashboardDropDownLinks linkBuilder={this.linkBuilder} linkList={window.ALL_CLAIMS} currentUser={user} />)}
         </CardHeader>
 
         { this.renderContentView() }

--- a/dashboard/of-cloud-dashboard/handler.js
+++ b/dashboard/of-cloud-dashboard/handler.js
@@ -123,6 +123,13 @@ module.exports = (event, context) => {
 
     let content = data.toString();
 
+    function get_all_claims(organizations, decodedCookie) {
+      if (decodedCookie && organizations.length > 0) {
+        return  organizations + "," + decodedCookie["sub"];
+      }
+      return ""
+    }
+
     if (!headers['Content-Type']) {
       headers['Content-Type'] = 'text/html';
 
@@ -137,13 +144,15 @@ module.exports = (event, context) => {
             .succeed();
       }
 
+      let claims = get_all_claims(organizations, decodedCookie);
+
       const { base_href, public_url, pretty_url, query_pretty_url } = process.env;
       content = content.replace(/__BASE_HREF__/g, base_href);
       content = content.replace(/__PUBLIC_URL__/g, public_url);
       content = content.replace(/__PRETTY_URL__/g, pretty_url);
       content = content.replace(/__QUERY_PRETTY_URL__/g, query_pretty_url);
       content = content.replace(/__IS_SIGNED_IN__/g, isSignedIn);
-      content = content.replace(/__ORGANIZATIONS__/g, organizations);
+      content = content.replace(/__ALL_CLAIMS__/g, claims);
 
     }
 


### PR DESCRIPTION
#  Description
We can now navigate to the other organisations that a
user has the claims to see, based on their cookie.
If a user does not have a cookie (no-auth deploy)
or a user only has 1 claim (no orgs)  then we dont display
the dropdown

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

closes #548 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deploying to ofc, with auth: 
<img width="1288" alt="Screenshot 2019-11-18 at 10 15 48" src="https://user-images.githubusercontent.com/40488132/69048415-4e172a80-09f5-11ea-9d82-bd5fec4b5532.png">


and without auth (therefore no concept of which ones people are allowed to see and members of)
<img width="1118" alt="Screenshot 2019-11-18 at 11 17 27" src="https://user-images.githubusercontent.com/40488132/69048447-5cfddd00-09f5-11ea-9dd8-7338f9ca0268.png">


## How are existing users impacted? What migration steps/scripts do we need?
If they have auth enabled they will see a new dropdown to navigate to their organisations.
If they are not using auth, then no change

A user will need to re-deploy the latest system-dashboard component to see these changes (once tag is released)


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
