### PR TITLE
Replace hard coded github.com with variable

### DIFF
--- a/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
+++ b/dashboard/client/src/components/FunctionDetailSummary/FunctionDetailSummary.jsx
@@ -98,7 +98,7 @@ const FunctionDetailSummary = ({
       label: 'Repository:',
       renderValue() {
         return (
-          <a href={`https://github.com/${repo}`} target="_blank">
+          <a href={fn.gitRepoURL} target="_blank">
             {repo}
           </a>
         );


### PR DESCRIPTION
## Description

There was a link on the function detail page that was pinned to
github.com (as string) rather than using the function's reported
location, which could have been gitlab

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed to my OFC cluster, links render for github.com still (dont have a gitlab cluster to test on)

## How are existing users impacted? What migration steps/scripts do we need?
New Dashboard required, this should fix an issue with Gitlab link, which nobody has reported, but might happen

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
