### PR TITLE
[WIP] Allow user to use tail and/or since param when querying logs

### DIFF
--- a/dashboard/client/src/App.css
+++ b/dashboard/client/src/App.css
@@ -175,3 +175,7 @@ a {
 .overflow-hidden {
     overflow: hidden;
 }
+
+.reload-width {
+    width: 32px !important;
+}

--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -180,11 +180,13 @@ class FunctionsApi {
 
   fetchFunctionLog({
                   longFnName,
-                  user
+                  user,
+                  numLines,
+                  since
                 }) {
     const url = `${
         this.apiBaseUrl
-    }/function-logs?function=${longFnName}&user=${user}`;
+    }/function-logs?function=${longFnName}&user=${user}&numLines=${numLines}&since=${since}`;
     return axios.get(url).then(res => {
       return res.data;
     });


### PR DESCRIPTION
## Description

Allow user to use tail and/or since param when querying logs

## How Has This Been Tested?

Deployed the functions locally and tested

<!--- Include details of your testing environment, and the tests you ran to -->

Tested the functions manually using API as well as the UI

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests


I still need help to place the elements correctly on the UI.