### PR TITLE
Rename tests in buildshiprun

### DIFF
--- a/buildshiprun/handler_test.go
+++ b/buildshiprun/handler_test.go
@@ -111,28 +111,28 @@ func Test_GetImageName(t *testing.T) {
 		Output            string
 	}{
 		{
-			"Test Docker Hub with user-prefix",
+			"Test Docker Hub with user-prefix finds correct image name",
 			"docker.io/of-community/",
 			"docker.io/of-community/",
 			"docker.io/of-community/function-name/",
 			"docker.io/of-community/function-name/",
 		},
 		{
-			"Testcase1",
+			"Test Swarm registry default port finds correct image name",
 			"registry:5000",
 			"127.0.0.1:5000",
 			"registry:5000/username/function-name/",
 			"127.0.0.1:5000/username/function-name/",
 		},
 		{
-			"Testcase2",
+			"Test Kubernetes registry default port finds correct image name",
 			"registry:31115",
 			"127.0.0.1:31115",
 			"registry:31115/username/function-name/",
 			"127.0.0.1:31115/username/function-name/",
 		},
 		{
-			"Testcase3",
+			"Test a registry without a port finds correct image name",
 			"registry:31115",
 			"127.0.0.1",
 			"registry:31115/username/function-name/",


### PR DESCRIPTION
## Description
Some of the tests had TestCase1 type names, these
have been changed to be more descriptive so a user
can debug more easily if these fail.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

closes #60 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
running tests

## How are existing users impacted? What migration steps/scripts do we need?
no impact


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
