### PR TITLE
Add validation for custom templates

### DIFF
--- a/git-tar/function/handler.go
+++ b/git-tar/function/handler.go
@@ -114,7 +114,7 @@ func Handle(req []byte) []byte {
 		os.Exit(-1)
 	}
 
-	stack, err := parseYAML(pushEvent, clonePath)
+	stack, err := parseYAML(clonePath)
 	if err != nil {
 		log.Println("parseYAML ", err.Error())
 		status.AddStatus(sdk.StatusFailure, "parseYAML error : "+err.Error(), sdk.StackContext)
@@ -157,7 +157,7 @@ func Handle(req []byte) []byte {
 	}
 
 	var shrinkWrapPath string
-	shrinkWrapPath, err = shrinkwrap(pushEvent, clonePath)
+	shrinkWrapPath, err = shrinkwrap(clonePath)
 	if err != nil {
 		log.Println("Shrinkwrap ", err.Error())
 		status.AddStatus(sdk.StatusFailure, "shrinkwrap error : "+err.Error(), sdk.StackContext)

--- a/git-tar/function/ops_test.go
+++ b/git-tar/function/ops_test.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -295,6 +296,48 @@ func Test_checkCompatibleTemplates(t *testing.T) {
 	}
 }
 
+func Test_JoinErrors_Single_Error(t *testing.T) {
+	err := fmt.Errorf("%s, %s", "http://some-repo", errors.New("some Error"))
+	list := []error{err}
+	want := fmt.Errorf("%s, %s\n", "http://some-repo", errors.New("some Error"))
+	got := joinErrors(list)
+
+	if got == nil {
+		t.Error("Expected Error, got nil")
+	}
+
+	if got.Error() != want.Error() {
+		t.Errorf("Expected %v: got: %v", want, got)
+	}
+}
+
+func Test_JoinErrors_Multiple_Errors(t *testing.T) {
+	err := fmt.Errorf("%s, %s", "http://some-repo", errors.New("some Error"))
+	list := []error{err, err}
+	want := fmt.Errorf("%s, %s\n", "http://some-repo", errors.New("some Error"))
+	got := joinErrors(list)
+
+	if got == nil {
+		t.Error("Expected Error, got nil")
+	}
+	wantErr := fmt.Sprintf("%s\n%s\n", err.Error(), err.Error())
+
+	if got.Error() != wantErr {
+		t.Errorf("Expected %v: got: %v", want, got)
+	}
+}
+
+func Test_JoinErrors_No_Errors(t *testing.T) {
+	list := []error{}
+	got := joinErrors(list)
+
+	if got != nil {
+		t.Errorf("Expected nil , got %v", got)
+	}
+}
+
+
+
 func mockTempTemplatesDir(files []string, directory string) (string, error) {
 	permissions := 0744
 	tmpDir := os.TempDir()
@@ -315,3 +358,5 @@ func mockTempTemplatesDir(files []string, directory string) (string, error) {
 	}
 	return templatesDir, nil
 }
+
+


### PR DESCRIPTION
This adds url validation for custom templates and edits the test
to cover previous issues in function code.

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Description
Rebased the initial PR by Ivana, I have changed it slightly so it doesn't die if it finds an invalid template, it instead logs it to git-tar output.

I decided that if anyone has any old templates in there cluster config we don't want to break their installations, just give some more gentle nudges if people check the logs.

closes #321
closes #319 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests done by Ivana,

I have deployed this new service onto my cluster and put in an invalid template, this gives error output in the logs, but still builds if we are using a valid template

## How are existing users impacted? What migration steps/scripts do we need?
People will get new log lines if they have templates that are not valid.
Users should run a build and follow the logs to see if they ahve enabled any invalid templates:

`kubectl logs -n opoenfaas-fn deploy/git-tar -f`



A user will need to deploy this new service first with:
( we are assuming the next version of git-tar will be `0.16.1` if this is not the case then replace the version beelow`)

`kubectl set image deployment/git-tar git-tar=functions/git-tar:0.16.1 --record -n openfaas-fn`

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
