### PR TITLE
Fix dashboard link

### DIFF
--- a/github-status/handler_test.go
+++ b/github-status/handler_test.go
@@ -498,3 +498,20 @@ func Test_stackDeployEventCorrectUrlSubdomain(t *testing.T) {
 	}
 
 }
+
+func Test_stackDeployEventCorrectUrlOnFailure(t *testing.T) {
+	os.Setenv("gateway_public_url", "https://cloud.this.example.com:8080")
+
+	event := &sdk.Event{
+		Owner:   "alexellis",
+		Service: "stack-deploy",
+	}
+
+	val := buildPublicStatusURL("failure", sdk.BuildFunctionContext(event.Service), event)
+	want := "https://system.this.example.com:8080/dashboard/alexellis"
+
+	if val != want {
+		t.Errorf("building PublicURL: want %s, got %s", want, val)
+		t.Fail()
+	}
+}

--- a/github-status/handler_test.go
+++ b/github-status/handler_test.go
@@ -462,3 +462,39 @@ func Test_truncate(t *testing.T) {
 		})
 	}
 }
+
+func Test_stackDeployEventCorrectUrl(t *testing.T) {
+	os.Setenv("gateway_public_url", "https://cloud.example.com:8080")
+
+	event := &sdk.Event{
+		Owner:   "alexellis",
+		Service: "stack-deploy",
+	}
+
+	val := buildPublicStatusURL("success", sdk.BuildFunctionContext(event.Service), event)
+	want := "https://system.example.com:8080/dashboard/alexellis"
+
+	if val != want {
+		t.Errorf("building PublicURL: want %s, got %s", want, val)
+		t.Fail()
+	}
+
+}
+
+func Test_stackDeployEventCorrectUrlSubdomain(t *testing.T) {
+	os.Setenv("gateway_public_url", "https://cloud.this.example.com:8080")
+
+	event := &sdk.Event{
+		Owner:   "alexellis",
+		Service: "stack-deploy",
+	}
+
+	val := buildPublicStatusURL("success", sdk.BuildFunctionContext(event.Service), event)
+	want := "https://system.this.example.com:8080/dashboard/alexellis"
+
+	if val != want {
+		t.Errorf("building PublicURL: want %s, got %s", want, val)
+		t.Fail()
+	}
+
+}


### PR DESCRIPTION
## Description
On Github, when a user's stack-deploy event sucseeded the url pointed at their function domain, so in my case `waterdrips.o6s.io` for the community cluster, now it points to the dashboard for that user, so `system.o6s.io/dashboard/Waterdrips`

Also on failure this stack-deploy event link pointed to some non-existent location where a function would have been, based on the stack-deploy event name. Thus now also points to the user's dashboard.


Also, found an issue that when we renamed "log" page to "build-log" and "function-log" I missed updating this link from github-status, so it pointed at non-existent page :(

closes #330 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, and deployed to my own OFC cluster and tests the stack-deploy success and failure scenarios, as well as failed and successful function builds (still point to correct places)

## How are existing users impacted? What migration steps/scripts do we need?
A new github-status image is needed and a user can update by editing the docker image of the github-status deployment.

The version is yet to be released but will probably be: `functions/git-status:0.3.7` - this image name is assumed for the rest of this section, if it is not correct then replace as appropriate

this can be updated by running: 

`kubectl set image deployment/github-status github-status=functions/github-status:0.3.7 --record -n openfaas-fn`

This is assuming the user is using a GitHub integration. Gitlab users need not change anything

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
