### PR TITLE
Function logs when scaled to 0 gives warning

### DIFF
--- a/dashboard/client/src/api/functionsApi.js
+++ b/dashboard/client/src/api/functionsApi.js
@@ -190,9 +190,13 @@ class FunctionsApi {
     const url = `${
         this.apiBaseUrl
     }/function-logs?function=${longFnName}&user=${user}`;
+
     return axios.get(url).then(res => {
-      return res.data;
-    });
+          return res.data;
+        }).catch(
+          fail => {
+            throw Error("Failed to fetch function logs - is the function scaled to 0? \nmessage:" + fail.message)
+        });
   }
 }
 


### PR DESCRIPTION
## Description

When we get an error fetching function logs then we now give a
warning that it could be due to functions being scaled to zero.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

closes #575 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed onto my OFC installation, waited for fn to scale to zero and tried to fetch logs:
![Screenshot from 2020-01-04 15-45-40](https://user-images.githubusercontent.com/40488132/71768083-e8caba80-2f0a-11ea-8af3-b684a6e5d4d7.png)

then invoked the function and got logs again:



![Screenshot from 2020-01-04 15-55-17](https://user-images.githubusercontent.com/40488132/71768081-dea8bc00-2f0a-11ea-997a-b326d9ee51dd.png)

## How are existing users impacted? What migration steps/scripts do we need?
Upgrade of the OFC dashboard needed once it is released


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
