### PR TITLE
Skip build of non-build branch

### DIFF
--- a/github-push/handler.go
+++ b/github-push/handler.go
@@ -68,7 +68,7 @@ func Handle(req []byte) string {
 
 	if buildBranch := buildBranch(); len(pushEvent.Ref) == 0 ||
 		pushEvent.Ref != fmt.Sprintf("refs/heads/%s", buildBranch) {
-		msg := fmt.Sprintf("refusing to build target branch: %s, want branch: %s", pushEvent.Ref, buildBranch)
+		msg := fmt.Sprintf("skipping build for: %s branch, the build branch is: %s", pushEvent.Ref, buildBranch)
 		auditEvent := sdk.AuditEvent{
 			Message: msg,
 			Owner:   pushEvent.Repository.Owner.Login,
@@ -78,7 +78,7 @@ func Handle(req []byte) string {
 
 		audit.Post(auditEvent)
 
-		status.AddStatus(sdk.StatusFailure, msg, sdk.StackContext)
+		status.AddStatus(sdk.StatusSuccess, msg, sdk.StackContext)
 		reportGitHubStatus(status)
 		return msg
 	}

--- a/github-push/handler_test.go
+++ b/github-push/handler_test.go
@@ -27,7 +27,7 @@ func Test_Handle_Push_InvalidBranch(t *testing.T) {
 		`{"ref":"refs/heads/staging"}`,
 	))
 
-	want := "refusing to build target branch: refs/heads/staging, want branch: master"
+	want := "skipping build for: refs/heads/staging branch, the build branch is: master"
 	if res != want {
 		t.Errorf("want error: \"%s\", got: \"%s\"", want, res)
 		t.Fail()

--- a/gitlab-push/handler.go
+++ b/gitlab-push/handler.go
@@ -228,7 +228,7 @@ func checkBranch(branchRef string) (branchErr error) {
 	buildBranch := getBranch()
 	branchFromRef := filterBranchRef(branchRef)
 	if buildBranch != branchFromRef {
-		msg := fmt.Sprintf("refusing to build target branch: %s, want branch: %s",
+		msg := fmt.Sprintf("skipping build for: %s branch, the build branch is: %s",
 			branchFromRef,
 			buildBranch)
 		branchErr = fmt.Errorf(msg)

--- a/gitlab-push/handler_test.go
+++ b/gitlab-push/handler_test.go
@@ -126,7 +126,7 @@ func Test_checkBranch(t *testing.T) {
 			title:         "Branch does not exist in environmental variables",
 			branchesInEnv: "staging",
 			branchRef:     "/refs/heads/development",
-			expectedError: errors.New("refusing to build target branch: development, want branch: staging"),
+			expectedError: errors.New("skipping build for: development branch, the build branch is: staging"),
 		},
 	}
 	for _, test := range tests {

--- a/gitlab.yml
+++ b/gitlab.yml
@@ -26,6 +26,23 @@ functions:
       - payload-secret
       - gitlab-api-token
 
+  gitlab-push:
+    lang: go
+    handler: ./gitlab-push
+    image: functions/gitlab-push:0.2.3
+    labels:
+      openfaas-cloud: "1"
+      role: openfaas-system
+      com.openfaas.scale.zero: false
+    environment:
+      write_debug: true
+      read_debug: true
+      build_branch: "master"
+    environment_file:
+      - gateway_config.yml
+    secrets:
+      - payload-secret
+
   gitlab-status:
     lang: go
     handler: ./gitlab-status
@@ -41,21 +58,4 @@ functions:
       - gateway_config.yml
     secrets:
       - gitlab-api-token
-      - payload-secret
-
-  gitlab-push:
-    lang: go
-    handler: ./gitlab-push
-    image: functions/gitlab-push:0.2.2
-    labels:
-      openfaas-cloud: "1"
-      role: openfaas-system
-      com.openfaas.scale.zero: false
-    environment:
-      write_debug: true
-      read_debug: true
-      build_branch: "master"
-    environment_file:
-      - gateway_config.yml
-    secrets:
       - payload-secret

--- a/stack.yml
+++ b/stack.yml
@@ -26,7 +26,7 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: functions/github-push:0.7.3
+    image: functions/github-push:0.7.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Rather than failing the commit status, OFC now reports a pass
status and an informational message about skipping the branch.

This is being changed in repsonse to customer feedback about
red X marks being undesirable on non-build branches.

Closes: #583

Unit tests updated and passing.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
