### PR TITLE
Lowercase the creation of ecr registries

### DIFF
--- a/register-image/handler.go
+++ b/register-image/handler.go
@@ -26,7 +26,7 @@ func (r ImageRequest) GetRepository() string {
 	if tagIndex > -1 {
 		image = image[:tagIndex]
 	}
-	return image
+	return strings.ToLower(image)
 }
 
 // Handle accepts an ImageRequest and creates the registry entry if required

--- a/register-image/handler_test.go
+++ b/register-image/handler_test.go
@@ -39,3 +39,15 @@ func Test_GetImageStripsECRRegistry(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func Test_GetImageLowecasesRegistryName(t *testing.T) {
+	r := ImageRequest{Image: "1238475.dkr.ecr.eu-central-1.amazonaws.com/ofbuilder/go-for-IT"}
+
+	got := r.GetRepository()
+	want := "ofbuilder/go-for-it"
+
+	if got != want {
+		t.Errorf("GetRepository want: %s, got %s", want, got)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
#Description 

ECR call was failing for users with any uppercase in their usernames. I
had this... annoying.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested on a ECR enabled cluster, it creates the repo,
pushes images and pulls them correctly.

## How are existing users impacted? What migration steps/scripts do we need?
Users with Uppercase usernames can now push to ECR.


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests