### PR TITLE
[Feature request] Support Github Orgs as Customers in edge-auth

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -142,7 +142,8 @@ private_key_filename: my-private-key
 
 Edit `customers_url` in gateway_config.yml.
 
-Enter a list of GitHub usernames for your customers, these are case-sensitive.
+Enter a list of GitHub usernames for your customers, these are case-sensitive. You can use Organisations in place of 
+usernames, anyone that is a public member of the organisation can then login.
 
 ### Customize for Kubernetes or Swarm
 

--- a/edge-auth/Makefile
+++ b/edge-auth/Makefile
@@ -1,7 +1,7 @@
 TAG?=latest
-
+NAMESPACE?=openfaas
 build:
-	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/edge-auth:$(TAG) .
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t $(NAMESPACE)/edge-auth:$(TAG) .
 
 push:
-	docker push openfaas/edge-auth:$(TAG)
+	docker push $(NAMESPACE)/edge-auth:$(TAG)

--- a/edge-auth/handlers/common.go
+++ b/edge-auth/handlers/common.go
@@ -24,6 +24,10 @@ type OpenFaaSCloudClaims struct {
 	jwt.StandardClaims
 }
 
+func (c OpenFaaSCloudClaims) GetOrganizations() []string {
+	return strings.Split(c.Organizations, ",")
+}
+
 // ProviderAccessToken as issued by GitHub or GitLab
 type ProviderAccessToken struct {
 	AccessToken string `json:"access_token"`

--- a/edge-auth/handlers/query.go
+++ b/edge-auth/handlers/query.go
@@ -124,8 +124,10 @@ func validCookie(r *http.Request, cookieName string, publicKey crypto.PublicKey,
 				log.Printf("Validated JWT for (%s) %s", claims.Subject, claims.Name)
 			}
 			if found, _ := customers.Get(claims.Subject); found == false {
-				log.Printf("user [%s] was not a valid customer", claims.Subject)
-				return http.StatusUnauthorized
+				if !isInOrganisations(claims, customers) {
+					log.Printf("user [%s] was not a valid customer", claims.Subject)
+					return http.StatusUnauthorized
+				}
 			}
 
 			if debug {
@@ -138,4 +140,13 @@ func validCookie(r *http.Request, cookieName string, publicKey crypto.PublicKey,
 	}
 
 	return http.StatusUnauthorized
+}
+
+func isInOrganisations(claims OpenFaaSCloudClaims, customers *sdk.Customers) bool {
+	for _, org := range claims.GetOrganizations() {
+		if found, _ := customers.Get(org); found == true {
+			return true
+		}
+	}
+	return false
 }

--- a/edge-auth/handlers/query_test.go
+++ b/edge-auth/handlers/query_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"github.com/dgrijalva/jwt-go"
+	"github.com/openfaas/openfaas-cloud/sdk"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_isInOrganisations_NoOrgs(t *testing.T) {
+	want := false
+	claims := OpenFaaSCloudClaims{
+		Name:           "claim",
+		AccessToken:    "token",
+		Organizations:  "",
+		StandardClaims: jwt.StandardClaims{},
+	}
+
+	usernames := make(map[string]string)
+	usernames["user"] = "user"
+	customers := sdk.Customers{
+		Usernames:     &usernames,
+		Sync:          &sync.Mutex{},
+		Expires:       time.Now().Add(100 * time.Second),
+		CustomersURL:  "",
+		CustomersPath: "",
+	}
+	got := isInOrganisations(claims, &customers)
+
+	if want != got {
+		t.Error("didn't expect to find user's org in Customers but did")
+		t.Fail()
+	}
+}
+
+func Test_isInOrganisations_OrgsNotMember(t *testing.T) {
+	want := false
+	claims := OpenFaaSCloudClaims{
+		Name:           "claim",
+		AccessToken:    "token",
+		Organizations:  "this,that",
+		StandardClaims: jwt.StandardClaims{},
+	}
+
+	usernames := make(map[string]string)
+	usernames["user"] = "user"
+	customers := sdk.Customers{
+		Usernames:     &usernames,
+		Sync:          &sync.Mutex{},
+		Expires:       time.Now().Add(100 * time.Second),
+		CustomersURL:  "",
+		CustomersPath: "",
+	}
+	got := isInOrganisations(claims, &customers)
+
+	if want != got {
+		t.Error("didn't expect to find user's org in Customers but did")
+		t.Fail()
+	}
+}
+
+func Test_isInOrganisations_IsInOrgs(t *testing.T) {
+	want := true
+	claims := OpenFaaSCloudClaims{
+		Name:           "claim",
+		AccessToken:    "token",
+		Organizations:  "this,that",
+		StandardClaims: jwt.StandardClaims{},
+	}
+
+	usernames := make(map[string]string)
+	usernames["this"] = "this"
+	customers := sdk.Customers{
+		Usernames:     &usernames,
+		Sync:          &sync.Mutex{},
+		Expires:       time.Now().Add(100 * time.Second),
+		CustomersURL:  "",
+		CustomersPath: "",
+	}
+	got := isInOrganisations(claims, &customers)
+
+	if want != got {
+		t.Error("wanted to find user's org in Customers but didn't")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
## Description
This Commit adds support for using a github Organisation as a "Customer"
in the customers file. This means users can manage their access controls
using github organisations rather than having to add/remove from the
customers file.


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by only having an organisation in the Customers file, checking
that I didnt get access with the previous version of edge-auth, then
changing to use my new version and I was issued a token and could access
the dashboard

Unit tests written

## How are existing users impacted? What migration steps/scripts do we need?
Any users who have an organisation in their Customers file will give access to public members of that organisation if they don't already exist in the ACL.

Users who wish to manage their ACL using github organisations can now use the organisation in the Customers file. Then only need to add/remove users from the organisation to give access.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
