### PR TITLE
Query all authorized GitHub orgs for users

### DIFF
--- a/edge-auth/README.md
+++ b/edge-auth/README.md
@@ -44,7 +44,7 @@ Please note - You need to be a public member of any Organisation that you wish t
 ## Building
 
 ```
-export TAG=0.7.1
+export TAG=0.7.2
 make build push
 ```
 

--- a/edge-auth/handlers/oauth2.go
+++ b/edge-auth/handlers/oauth2.go
@@ -190,7 +190,9 @@ func createSession(token ProviderAccessToken, privateKey crypto.PrivateKey, conf
 	organizationList := ""
 
 	if providerName == "github" {
-		organizations, organizationsErr := getUserOrganizations(profile.Login, token.AccessToken)
+		github := provider.NewGitHub(http.DefaultClient)
+
+		organizations, organizationsErr := github.GetUserOrganizations(token.AccessToken)
 		if organizationsErr != nil {
 			return session, organizationsErr
 		}
@@ -232,50 +234,4 @@ func getToken(res *http.Response) (ProviderAccessToken, error) {
 	}
 
 	return token, fmt.Errorf("no body received from server")
-}
-
-func getUserOrganizations(username, accessToken string) (string, error) {
-
-	organizations := []Organization{}
-	apiURL := fmt.Sprintf("https://api.github.com/users/%s/orgs", username)
-
-	req, reqErr := http.NewRequest(http.MethodGet, apiURL, nil)
-	if reqErr != nil {
-		return "", fmt.Errorf("error while making request to `%s` organizations: %s", apiURL, reqErr.Error())
-	}
-	req.Header.Add("Authorization", "token "+accessToken)
-
-	client := http.DefaultClient
-	resp, respErr := client.Do(req)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
-	if respErr != nil {
-		return "", fmt.Errorf("error while requesting organizations: %s", respErr.Error())
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("bad status code from request to GitHub organizations: %d", resp.StatusCode)
-	}
-
-	body, bodyErr := ioutil.ReadAll(resp.Body)
-	if bodyErr != nil {
-		return "", fmt.Errorf("error while reading body from GitHub organizations: %s", bodyErr.Error())
-	}
-
-	var allOrganizations []string
-	unmarshallErr := json.Unmarshal(body, &organizations)
-	if unmarshallErr != nil {
-		return "", fmt.Errorf("error while un-marshaling organizations: %s", unmarshallErr.Error())
-	}
-
-	for _, organization := range organizations {
-		allOrganizations = append(allOrganizations, organization.Login)
-	}
-	formatOrganizations := strings.Join(allOrganizations, ",")
-
-	return formatOrganizations, nil
-}
-
-type Organization struct {
-	Login string `json:"login"`
 }

--- a/edge-auth/provider/github_profile.go
+++ b/edge-auth/provider/github_profile.go
@@ -107,9 +107,9 @@ func (gh *GitHub) GetUserOrganizations(accessToken string) (string, error) {
 	}
 
 	var allOrganizations []string
-	unmarshallErr := json.Unmarshal(body, &organizations)
-	if unmarshallErr != nil {
-		return "", fmt.Errorf("error while un-marshaling organizations: %s", unmarshallErr.Error())
+	unmarshalErr := json.Unmarshal(body, &organizations)
+	if unmarshalErr != nil {
+		return "", fmt.Errorf("error while un-marshaling organizations: %s, value: %q", unmarshalErr.Error(), body)
 	}
 
 	for _, organization := range organizations {

--- a/edge-auth/provider/github_profile.go
+++ b/edge-auth/provider/github_profile.go
@@ -124,5 +124,5 @@ func formatOrganizations(orgs []Organization) string {
 
 type Organization struct {
 	Login string `json:"login"`
-	ID    string `json:"id"`
+	ID    int    `json:"id"`
 }

--- a/edge-auth/provider/github_profile.go
+++ b/edge-auth/provider/github_profile.go
@@ -77,8 +77,6 @@ type GitHubProfile struct {
 // GetUserOrganizations using the API "List your organizations"
 // https://developer.github.com/v3/orgs/#list-your-organizations
 func (gh *GitHub) GetUserOrganizations(accessToken string) (string, error) {
-	organizations := []Organization{}
-
 	apiURL := fmt.Sprintf("https://api.github.com/user/orgs")
 
 	req, reqErr := http.NewRequest(http.MethodGet, apiURL, nil)
@@ -106,20 +104,25 @@ func (gh *GitHub) GetUserOrganizations(accessToken string) (string, error) {
 		return "", fmt.Errorf("error while reading body from GitHub organizations: %s", bodyErr.Error())
 	}
 
-	var allOrganizations []string
-	unmarshalErr := json.Unmarshal(body, &organizations)
+	var orgs []Organization
+	unmarshalErr := json.Unmarshal(body, &orgs)
 	if unmarshalErr != nil {
 		return "", fmt.Errorf("error while un-marshaling organizations: %s, value: %q", unmarshalErr.Error(), body)
 	}
 
-	for _, organization := range organizations {
-		allOrganizations = append(allOrganizations, organization.Login)
-	}
-	formatOrganizations := strings.Join(allOrganizations, ",")
+	return formatOrganizations(orgs), nil
+}
 
-	return formatOrganizations, nil
+func formatOrganizations(orgs []Organization) string {
+	logins := []string{}
+	for _, organization := range orgs {
+		logins = append(logins, organization.Login)
+	}
+
+	return strings.Join(logins, ",")
 }
 
 type Organization struct {
 	Login string `json:"login"`
+	ID    string `json:"id"`
 }

--- a/edge-auth/provider/github_profile.go
+++ b/edge-auth/provider/github_profile.go
@@ -89,12 +89,14 @@ func (gh *GitHub) GetUserOrganizations(accessToken string) (string, error) {
 	req.Header.Add("Authorization", "token "+accessToken)
 
 	resp, respErr := gh.Client.Do(req)
-	if resp.Body != nil {
-		defer resp.Body.Close()
-	}
 	if respErr != nil {
 		return "", fmt.Errorf("error while requesting organizations: %s", respErr.Error())
 	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("bad status code from request to GitHub organizations: %d", resp.StatusCode)
 	}

--- a/edge-auth/provider/types_test.go
+++ b/edge-auth/provider/types_test.go
@@ -1,6 +1,10 @@
 package provider
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
 
 func TestSupportedProviders_IsSupported_whenProviderIsSupported(t *testing.T) {
 	if !IsSupported("github") {
@@ -19,5 +23,27 @@ func TestSupportedProviders_IsSupported_whenProviderIsSupported(t *testing.T) {
 func TestSupportedProviders_IsSupported_whenProviderIsNotSupported(t *testing.T) {
 	if IsSupported("foobar.com") {
 		t.Errorf("Want: \"%v\". Got: \"%v\"", false, true)
+	}
+}
+
+func TestUnmarshalOrg(t *testing.T) {
+	wantID := 49474643
+	wantLogin := "teamserverless"
+	orgVal := []byte(fmt.Sprintf(`{"login": "%s","id": %d}`, wantLogin, wantID))
+
+	org := Organization{}
+	err := json.Unmarshal(orgVal, &org)
+
+	if err != nil {
+		t.Errorf("received error, wanted none: %s", err.Error())
+		t.Fail()
+	}
+	if org.ID != wantID {
+		t.Errorf("ID want: %d, got: %d", wantID, org.ID)
+		t.Fail()
+	}
+	if org.Login != wantLogin {
+		t.Errorf("Login want: %s, got: %s", wantLogin, org.Login)
+		t.Fail()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Query all authorized GitHub orgs for users

## Context

Prior to this change, public visibility was required for GitHub
users in each organisation due to the API being used:

GET /users/:username/orgs

This has been changed to use the following:

GET /user/orgs

Via:

https://developer.github.com/v3/orgs/#list-your-organizations

Thanks to @Waterdrips for the suggestion.

Available for testing in: `openfaas/edge-auth:0.7.2`