### PR TITLE
Fix SealedSecrets regression

### DIFF
--- a/import-secrets/handler.go
+++ b/import-secrets/handler.go
@@ -59,7 +59,7 @@ func Handle(req []byte) string {
 	err = yaml.Unmarshal(req, &userSecret)
 
 	if err != nil {
-		fmt.Println("couldn't unmarshall secrets.yml\n", err)
+		fmt.Println("couldn't unmarshal secrets.yml\n", err)
 		os.Exit(-1)
 	}
 
@@ -128,7 +128,7 @@ func updateEncryptedData(ss *ssv1alpha1.SealedSecret, userSecret *SealedSecret) 
 			return fmt.Errorf("can't decode base64 string (%s) - error: %s", k, err)
 		}
 
-		ss.Spec.EncryptedData[k] = string(encodedBytes)
+		ss.Spec.EncryptedData[k] = base64.StdEncoding.EncodeToString(encodedBytes)
 	}
 
 	return nil
@@ -146,13 +146,13 @@ type eventInfo struct {
 	owner string
 }
 
-type SealedSecretSpec struct {
-	EncryptedData map[string]string `yaml:"encryptedData"`
-}
-
 type SealedSecret struct {
 	ApiVersion string             `yaml:"apiVersion"`
 	Kind       string             `yaml:"kind"`
 	Metadata   *metav1.ObjectMeta `yaml:"metadata"`
 	Spec       SealedSecretSpec   `yaml:"spec"`
+}
+
+type SealedSecretSpec struct {
+	EncryptedData map[string]string `yaml:"encryptedData"`
 }

--- a/stack.yml
+++ b/stack.yml
@@ -136,7 +136,7 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: functions/import-secrets:0.6.1
+    image: functions/import-secrets:0.6.2
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Unfortunately PR #596 by @heyts appears to have not been tested
end-to-end and caused an outage for OpenFaaS Cloud users when
upgrading.

This change encodes the secret data value correctly for use
with the latest SealedSecrets version.

Ref: https://github.com/bitnami-labs/sealed-secrets/pull/206

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

Before:

```
{
    "apiVersion": "bitnami.com/v1alpha1",
    "kind": "SealedSecret",
    "metadata": {
        "creationTimestamp": "2020-03-05T15:59:20Z",
        "generation": 1,
        "name": "alexellis-tester",
        "namespace": "openfaas-fn",
        "resourceVersion": "170219638",
        "selfLink": "/apis/bitnami.com/v1alpha1/namespaces/openfaas-fn/sealedsecrets/alexellis-tester",
        "uid": "462d71a9-5efa-11ea-aea5-6622081dcfa1"
    },
    "spec": {
        "encryptedData": {
            "hello": "\u0002\u0000oؙ����*��\u0004�VȞ�.�EzAj�\u0014k��z�`�jj18Ag_\rKx��_�¨\u0011B��\u001e*/1#��v((\"7Λ!�4}�\u003ee\u000f��jK\u0001�O�����\u0018��\u0004���R�\u0011\u0018\u0005RG��\u0018�M��Ry�t��'�s\u0016a�r`\u0003́�S\u001a!\u0000�\u0016\u0006[B�᷀UG��h�^�6��僐�Uk��ɠ��9\u003e��Ո�\u001dLpNI��VQ#\u001a��P\u0019\u0005�\u0001�j}�%u��\u0005t�nG\t�h�=\u0004c@�F2���!hʉ�\u0003��\u0019y�e#V��B�������7�B��͑��\u0005A�/\u000f�i�;\u0013\u0019{��ҥ���\u000b�g��\u0006���J��U��\u0017�kN�\u0003��ɷzL=6�8\u003c�o\u0010F�R�\u0007�I=\u000e���B) ��@��\u001fV\u0010��O��|\u0002�4\u0010��n��65�\u000fw�\u0006�s��\u000e�N��W��\u0006y\u0015\u003e7\u0018��\u0016\u000b\u000f\u0018�{��\u0016��M��Z\u0016��j��\u0005p�T�\u001bj�2\u0017�;U3�=ss��\u0026;v�c��y�����r�pdDa޴�\u003c:KJt�\u0006��S\u000b�������j�#\u0004��B� Mpw:�\u0006+��\u0001\u000e�m�Cb��%ļ@l����\"l\u000c\u000b�{��\n��ݚ6��:5�\u0008O�IO�K��a\u00264�\u0007���WP?�\u0026_��C�"
        },
        "template": {
            "metadata": {
                "creationTimestamp": null
            }
        }
    },
    "status": {}
}
```

After:

```
apiVersion: bitnami.com/v1alpha1
kind: SealedSecret
metadata:
  creationTimestamp: "2020-03-05T16:02:04Z"
  generation: 1
  name: alexellis-tester
  namespace: openfaas-fn
  resourceVersion: "170220637"
  selfLink: /apis/bitnami.com/v1alpha1/namespaces/openfaas-fn/sealedsecrets/alexellis-tester
  uid: a8327789-5efa-11ea-aea5-6622081dcfa1
spec:
  encryptedData:
    hello: AgABJRBj/EnMxOP2CdZD5EcYOPOmCw4OICtL5RZHlIXO3ZaOaYvfxQ821nrKyf1s7TGEb+jNaA8/O2IEk9B2Q2nXIQXZc4sRLURRMlD+dCtuFK8C1FjIwrX4RM7squCvyS97EbS/EJbdw0DrTs8qIu+OfThei7pespKICjzdKkJKPqMQe752V2xf8B0vYOAAPbNWuQpRpZu/K1+p6naan0h45eFhBlKz8sT0zDYm4QR6jj+084mmA0ulUXZ8LwweXpbvjkRnnS8MHHkzfS1RWX4pziYL4pR5bw7cm2JGgFlLwjdeFi40+vdnHwhHI1VUGuftC6F45h2fvUWk9/0XUqm5iUQmc6AdTFl865mvjQWD/F3bx1YQtEOQLvwLM4e99Tu7BdGQ/SN5ugpBILUPXZBaaG/MHuwz+vvhLgubjWxWzaJpVn8snqhSJMkEQw81Vmf6pwJ4/wS7yYScUNBBO652FNAA+JMcGFIBLPfr71Rme9XmYPGDPDtxQWLFpis8UZqyG01K1/jktgz3RZGOVQ+YxtAcFBS/tdPrxcriCHxIuqJ8Lsw4fRGmQMef109msjMWCYDsywit1XsMJl7Y9f2Xb2ED2+1M3pBEPfoXEOCABcuXkK0eAFiVJmZPOD4+n6rUc/tAak37IpUzBj/YexHyxg1TZdk1DYgLtDE4SDmBTchBdHF/zzxK+xBYIolMOwqvrkFl88Am6w==
```
