### PR TITLE
Allow the use of Secure cookie for edge-auth

### DIFF
--- a/chart/openfaas-cloud/templates/ofc-core/edge-auth-dep.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/edge-auth-dep.yaml
@@ -82,6 +82,8 @@ spec:
               value: {{ printf "%s://auth.system.%s" .Values.global.scheme .Values.global.rootDomain | quote }}
             - name: cookie_root_domain
               value: {{ printf ".system.%s" .Values.global.rootDomain | quote }}
+            - name: secure_cookie
+              value: {{ .Values.tls.enabled | quote }}
             {{- if not .Values.customers.customersSecret }}
             - name: customers_url
               value: {{ required "A valid .Values.customers.url entry required!" .Values.customers.url | quote }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -510,6 +510,9 @@ Auth is optional and protects the dashboard from users accessing the page. It is
 
 To enable OAuth 2.0 we will need to set up a number of DNS entries or host file entries for local development.
 
+If you are using TLS to secure your application then you can enable the "Secure" setting on the cookie by updating the
+"secure_cookie" environment variable to "true" in the edge-auth deployment. Please see the installation guides 
+
 #### Disable auth for local development
 
 If you wish to disable Auth then you can change the edge-router's URL from `http://edge-auth:8080` (on Swarm) or `http://edge-auth.openfaas:8080` (on Kubernetes) to `http://echo:8080` or `http://echo.openfaas:8080` which will by-pass any need for a Cookie or JWT to be established by allowing the "echo" service to act as the authorziation. This works because the echo service will always return "200 OK" to requests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,7 @@
 - [x] Free to use SaaS edition for community members and contributors
 - [x] Log storage on Minio (S3-compatible)
 - [x] Log storage on AWS S3
-- [ ] Kubernetes helm chart (plain YAML supported already)
+- [x] Kubernetes helm chart (plain YAML supported already)
 - [ ] Automation for the day-0 installation via Ansible or similar
 
 * Developer story

--- a/edge-auth/Makefile
+++ b/edge-auth/Makefile
@@ -1,7 +1,7 @@
 TAG?=latest
-
+NAMESPACE?=openfaas
 build:
-	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t openfaas/edge-auth:$(TAG) .
+	docker build --build-arg http_proxy="${http_proxy}" --build-arg https_proxy="${https_proxy}" -t $(NAMESPACE)/edge-auth:$(TAG) .
 
 push:
-	docker push openfaas/edge-auth:$(TAG)
+	docker push $(NAMESPACE)/edge-auth:$(TAG)

--- a/edge-auth/handlers/config.go
+++ b/edge-auth/handlers/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Scope                  string
 	CookieRootDomain       string
 	CookieExpiresIn        time.Duration
+	SecureCookie           bool
 	PublicKeyPath          string
 	PrivateKeyPath         string
 	Debug                  bool // Debug enables verbose logging of claims / cookies

--- a/edge-auth/handlers/oauth2.go
+++ b/edge-auth/handlers/oauth2.go
@@ -153,6 +153,7 @@ func MakeOAuth2Handler(config *Config) func(http.ResponseWriter, *http.Request) 
 
 		http.SetCookie(w, &http.Cookie{
 			HttpOnly: true,
+			Secure:   config.SecureCookie,
 			Name:     cookieName,
 			Value:    session,
 			Path:     "/",

--- a/edge-auth/main.go
+++ b/edge-auth/main.go
@@ -30,6 +30,7 @@ func main() {
 	var oauthClientSecretPath string
 
 	var writeDebug bool
+	secureCookie := false
 
 	if val, exists := os.LookupEnv("oauth_provider"); exists {
 		oauthProvider = val
@@ -63,6 +64,13 @@ func main() {
 		cookieRootDomain = val
 	}
 
+	if val, exists := os.LookupEnv("secure_cookie"); exists {
+		if boolVal, err := strconv.ParseBool(val); err == nil {
+			secureCookie = boolVal
+		}
+		log.Printf("unable to convert %s to bool for %q", val, "secure_cookie")
+	}
+
 	if val, exists := os.LookupEnv("public_key_path"); exists {
 		publicKeyPath = val
 	}
@@ -88,6 +96,7 @@ func main() {
 		CookieRootDomain:       cookieRootDomain,
 		ExternalRedirectDomain: externalRedirectDomain,
 		Scope:                  "read:org,read:user,user:email",
+		SecureCookie:           secureCookie,
 		PublicKeyPath:          publicKeyPath,
 		PrivateKeyPath:         privateKeyPath,
 		OAuthClientSecretPath:  oauthClientSecretPath,

--- a/yaml/core/edge-auth-dep.yml
+++ b/yaml/core/edge-auth-dep.yml
@@ -73,6 +73,10 @@ spec:
           - name: cookie_root_domain
             value: ".system.o6s.io"
 
+# Config for setting the cookie to "secure", set this to true for HTTPS only OAuth
+          - name: secure_cookie
+            value: false
+
 # This is a default and can be overridden
           - name: customers_url
             value: "https://raw.githubusercontent.com/openfaas/openfaas-cloud/master/CUSTOMERS"


### PR DESCRIPTION
## Description
The "Secure" setting for cookies was not able to be set, we have enabled
the parameter and set it to default to `false`, maintaining existing
functionality.

Optionally a user can now set "secure_cookie" to true in the edge-auth
deployment and this will set the flag on the user's cookie, meaning it
will only be transmitted over HTTPS.

I have updated the Helm Chart to include this option. The images have not been bumped in the deployments as they have not been created yet. 

Fixes #605 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Logged into working installation.
Deleted Cookie
Updated a deployment with the new image, no secure_cookie env var set on the deployment:
got a cookie, and it was secure=false

Deleted cookie
Updated the same deployment to add the secure_cookie=true env var.
Authd with the OFC install, got a cookie and it had "secure=true" set.


Delete cookie
Updated the same deployment to change the secure_cookie to false.
Authd, got a cookie and it had "secure=false" set.


## How are existing users impacted? What migration steps/scripts do we need?
A user with an existing instillation, if they updated the image without adding the new env var they would see no change, and it would work.

A user who wanted to use TLS (recommended for production) could ensure that their cookies were only send over HTTPS. 

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
