### PR TITLE
Don't error if ECR Repository exists already

### DIFF
--- a/register-image/Gopkg.lock
+++ b/register-image/Gopkg.lock
@@ -80,6 +80,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ecr",
     "github.com/openfaas/openfaas-cloud/sdk",


### PR DESCRIPTION
## Description
We were returning an error if the ECR repo already exists. This shouldnt
give an error because it's not a failure. If the repo doesn't exist then
we create it, if it exists then that's fine.

Fixes #539 


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by deploying an ECR backed OFC installation, first time round it
creates the new repo, then after that it's not throwing an error, only
saying it already exists.

After - when trying to create repo that exists
```sh
2020/03/07 19:32:17 Attempting to create repo: waterdrips-openfaas-cloud-functions-roll
Repo Exists: waterdrips-openfaas-cloud-functions-roll

```

## How are existing users impacted? What migration steps/scripts do we need?
New deployment of register-image required. This fixes some output not to return an error.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
