### PR TITLE
Add memory limits to functions

### DIFF
--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -12,3 +12,8 @@ functions:
       role: openfaas-system
     environment_file:
       - dashboard_config.yml
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 64Mi
+      cpu: 50m

--- a/gitlab.yml
+++ b/gitlab.yml
@@ -26,6 +26,11 @@ functions:
       - payload-secret
       - gitlab-api-token
       - customers
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   gitlab-push:
     lang: go
@@ -44,6 +49,11 @@ functions:
     secrets:
       - payload-secret
       - customers
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   gitlab-status:
     lang: go
@@ -61,3 +71,8 @@ functions:
     secrets:
       - gitlab-api-token
       - payload-secret
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m

--- a/stack.yml
+++ b/stack.yml
@@ -23,6 +23,11 @@ functions:
       - github-webhook-secret
       - payload-secret
       - customers
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   github-push:
     lang: go
@@ -45,6 +50,11 @@ functions:
       - github-webhook-secret
       - payload-secret
       - customers
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   git-tar:
     lang: dockerfile
@@ -67,6 +77,11 @@ functions:
       - private-key
   # Uncomment this for GitLab
   #      - gitlab-api-token
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   buildshiprun:
     lang: go
@@ -91,6 +106,11 @@ functions:
       - basic-auth-password
       - payload-secret
   #      - swarm-pull-secret
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   garbage-collect:
     lang: go
@@ -111,6 +131,11 @@ functions:
       - basic-auth-user
       - basic-auth-password
       - payload-secret
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   github-status:
     lang: go
@@ -132,6 +157,11 @@ functions:
     secrets:
       - private-key
       - payload-secret
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   import-secrets:
     lang: go
@@ -150,6 +180,11 @@ functions:
       - github.yml
     secrets:
       - payload-secret
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   pipeline-log:
     lang: go
@@ -169,6 +204,11 @@ functions:
       - s3-access-key
       - s3-secret-key
       - payload-secret
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   list-functions:
     lang: go
@@ -186,6 +226,11 @@ functions:
     secrets:
       - basic-auth-user
       - basic-auth-password
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   audit-event:
     lang: go
@@ -196,6 +241,11 @@ functions:
       com.openfaas.scale.zero: false
     environment_file:
       - slack.yml
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   echo:
     skip_build: true
@@ -207,6 +257,11 @@ functions:
     environment:
       write_debug: true
       read_debug: true
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   metrics:
     lang: go
@@ -220,6 +275,11 @@ functions:
       - gateway_config.yml
     environment:
       content_type: "application/json"
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   function-logs:
     lang: go
@@ -237,5 +297,10 @@ functions:
     secrets:
       - basic-auth-user
       - basic-auth-password
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
 


### PR DESCRIPTION
Adding memory limits to functions all except
the dashboard are set to limits.memory 128Mi
requests.memory 64Mi the dashboard's limits
are doubled. All functions have requests.cpu
limit of 50m

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

## Description

Closes #614 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested to verify limits are applied by `faas deploy -f stack.yml` in base folder and in dashboard:
```
$ kubectl describe deploy system-github-event -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy audit-event -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy buildshiprun -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy echo -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy function-logs -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy garbage-collect -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy git-tar -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy github-push -n openfaas-fn
...  
  Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy github-status -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy import-secrets -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy list-functions -n openfaas-fn
... 
   Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy metrics -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy pipeline-log -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy system-dashboard -n openfaas-fn
...
    Limits:
      memory:  256Mi
    Requests:
      cpu:      50m
      memory:   64Mi
...
$ kubectl describe deploy system-github-event -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
```
For gitlab ones:
```
$ kubectl describe deploy gitlab-push -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
...
$ kubectl describe deploy gitlab-status -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
$ kubectl describe deploy system-gitlab-event -n openfaas-fn
...
    Limits:
      memory:  128Mi
    Requests:
      cpu:      50m
      memory:   32Mi
```

## How are existing users impacted? What migration steps/scripts do we need?

They will have default memory limits when install the cloud

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
