### PR TITLE
Check cookie exists and subject on cookie before using

### DIFF
--- a/dashboard/of-cloud-dashboard/handler.js
+++ b/dashboard/of-cloud-dashboard/handler.js
@@ -101,14 +101,20 @@ module.exports = async (event, context) => {
 
     const isSignedIn = /openfaas_cloud_token=.*\s*/.test(event.headers.cookie);
 
-    console.log(path);
-
     if (path === "/" && isSignedIn) {
-      headers["Location"] =   "/dashboard/"+ decodedCookie["sub"];
+      let statusCode = 404
+
+      // If we have a cookie, and it has a subject, then redirect to the subject's dashboard
+      if (decodedCookie && decodedCookie["sub"]) {
+        headers["Location"] =   "/dashboard/"+ decodedCookie["sub"];
+        statusCode = 307
+      }
+
       return context
           .headers(headers)
-          .status(307)
-          .succeed();
+          .status(statusCode)
+          .succeed()
+      
     }
 
     let claims = get_all_claims(organizations, decodedCookie);


### PR DESCRIPTION
## Description

We were checking if we had a cookie, but not then checking if it was not
empty, and the subject was not empty before using it for redirecting to
the user's dashboard (If they navigated to / or /dashboard)

Fixes #623 

## How Has This Been Tested?

Tested by deploying new dashboard, deleting cookie, setting cookie to
empty string etc. All returned no error (but did show 401 not
authorized)

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


## How are existing users impacted? What migration steps/scripts do we need?
This is an edge-case which i was not able to replicate. New deployment of the dashboard to get the latest fix.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
