### PR TITLE
Add Cookie root domain env variable to Dashboard

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -81,7 +81,7 @@ Set `public_url` to be the URL for the IP / DNS of the OpenFaaS Cloud.
 
 Set `cookie_root_domain` when using auth.
 
-Example with domain `o6s.io`:
+Example with domain `.system.o6s.io`:
 
 ```
 cookie_root_domain: ".system.o6s.io"

--- a/dashboard/dashboard_config.yml
+++ b/dashboard/dashboard_config.yml
@@ -10,3 +10,5 @@ environment:
   pretty_url: https://user.o6s.io/function
   # Comment out if not using public pretty-URL
   query_pretty_url: 'true'
+  # Cookie root domain, set is using OAuth, used to remove a user's cookie
+  cookie_root_domain: 'system.o6s.io'


### PR DESCRIPTION
## Description

Somewhere along the line the cookie_root_domain was missed from the
dashboard config. This only needs to be set when using OAuth, to remove
a users token from their cookie. This was not set and therefore caused
us to try and set the cookie domain to "undefined"

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>
Fixes #632 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested by adding the env to the Dashboard deployment and
hitting logout on an OAuth enabled installation. This now sets the
correct cookie domain and removes the existing token


## How are existing users impacted? What migration steps/scripts do we need?
This is a bugfix, users will need to edit their dashboard deployment to add this environment variable

```
kubectl edit deploy -n openfaas-fn system-dashboard
```
and add the following to the environment variables section:
(example where your openfaas root domain is "example.com"
```
        - name: cookie_root_domain
          value: .system.example.com
```


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests


This will also need amending in ofc-bootstrap to propagate this change