### PR TITLE
Add support for limited build-args

### DIFF
--- a/git-tar/Dockerfile
+++ b/git-tar/Dockerfile
@@ -1,6 +1,6 @@
-FROM openfaas/faas-cli:0.11.8 as faas-cli
-FROM openfaas/classic-watchdog:0.18.1 as watchdog
-FROM golang:1.13-alpine3.11 as build
+FROM openfaas/faas-cli:0.12.8 as faas-cli
+FROM openfaas/classic-watchdog:0.18.17 as watchdog
+FROM golang:1.13-alpine3.12 as build
 
 ENV CGO_ENABLED=0
 ENV GO111MODULE=off

--- a/git-tar/Gopkg.lock
+++ b/git-tar/Gopkg.lock
@@ -46,15 +46,15 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:adcf8a1e316343fab29b10ecc194651d7ace0a03494b3a9dbc894c39455dfe98"
+  digest = "1:8b50ced9616d74c18f1727fd2246d7d18e3a6ed576b99cf81c0bd255039b3722"
   name = "github.com/openfaas/faas-cli"
   packages = [
     "schema",
     "stack",
   ]
   pruneopts = "UT"
-  revision = "5ff1504047756f9ff2e0a10ae64803ab63df470a"
-  version = "0.9.3"
+  revision = "16f6eb9522cff9622b78cbe6450d60f8b3cd7ead"
+  version = "0.12.8"
 
 [[projects]]
   digest = "1:deb76da5396c9f641ddea9ca79e31a14bdb09c787cdfda90488768b7539b1fd6"
@@ -73,11 +73,12 @@
   version = "0.13.3"
 
 [[projects]]
-  digest = "1:5b92d232e81c3e8eec282c92dcaa2e0e1ad3c23157be19a01b3e33f7e6e8d137"
+  digest = "1:6baa565fe16f8657cf93469b2b8a6c61a277827734400d27e44d589547297279"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
   pruneopts = "UT"
-  revision = "256dc444b735e061061cf46c809487313d5b0065"
+  revision = "51a8f68e6c24dc43f1e371749c89a267de4ebc53"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"

--- a/git-tar/Gopkg.toml
+++ b/git-tar/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/openfaas/faas-cli"
-  version = "0.9.3"
+  version = "0.12.8"
 
 [[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
@@ -25,5 +25,4 @@
 [prune]
   go-tests = true
   unused-packages = true
-
 

--- a/git-tar/function/types.go
+++ b/git-tar/function/types.go
@@ -1,0 +1,7 @@
+package function
+
+type buildConfig struct {
+	Ref       string            `json:"ref"`
+	Frontend  string            `json:"frontend,omitempty"`
+	BuildArgs map[string]string `json:"buildArgs,omitempty"`
+}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/schema/image.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/schema/image.go
@@ -46,16 +46,16 @@ func (i *BuildFormat) String() string {
 }
 
 // Set implements pflag.Value
-func (l *BuildFormat) Set(value string) error {
+func (i *BuildFormat) Set(value string) error {
 	switch strings.ToLower(value) {
 	case "", "default", "latest":
-		*l = DefaultFormat
+		*i = DefaultFormat
 	case "sha":
-		*l = SHAFormat
+		*i = SHAFormat
 	case "branch":
-		*l = BranchAndSHAFormat
+		*i = BranchAndSHAFormat
 	case "describe":
-		*l = DescribeFormat
+		*i = DescribeFormat
 	default:
 		return fmt.Errorf("unknown image tag format: '%s'", value)
 	}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/schema/metadata.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/schema/metadata.go
@@ -3,8 +3,9 @@
 
 package schema
 
-//Metadata metadata of the object
+// Metadata metadata of the object
 type Metadata struct {
-	Name      string `yaml:"name"`
-	Namespace string `yaml:"namespace,omitempty"`
+	Name        string            `yaml:"name,omitempty"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }

--- a/git-tar/vendor/github.com/openfaas/faas-cli/schema/secret.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/schema/secret.go
@@ -11,9 +11,3 @@ type KubernetesSecretMetadata struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
-
-//Secret secret type
-type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
-}

--- a/git-tar/vendor/github.com/openfaas/faas-cli/stack/schema.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/stack/schema.go
@@ -13,7 +13,8 @@ type Provider struct {
 // Function as deployed or built on FaaS
 type Function struct {
 	// Name of deployed function
-	Name     string `yaml:"-"`
+	Name string `yaml:"-"`
+
 	Language string `yaml:"lang"`
 
 	// Handler Local folder to use for function
@@ -30,35 +31,61 @@ type Function struct {
 	Environment map[string]string `yaml:"environment"`
 
 	// Secrets list of secrets to be made available to function
-	Secrets []string `yaml:"secrets"`
+	Secrets []string `yaml:"secrets,omitempty"`
 
-	SkipBuild bool `yaml:"skip_build"`
+	SkipBuild bool `yaml:"skip_build,omitempty"`
 
-	Constraints *[]string `yaml:"constraints"`
+	Constraints *[]string `yaml:"constraints,omitempty"`
 
 	// EnvironmentFile is a list of files to import and override environmental variables.
 	// These are overriden in order.
-	EnvironmentFile []string `yaml:"environment_file"`
+	EnvironmentFile []string `yaml:"environment_file,omitempty"`
 
-	Labels *map[string]string `yaml:"labels"`
+	Labels *map[string]string `yaml:"labels,omitempty"`
 
 	// Limits for function
-	Limits *FunctionResources `yaml:"limits"`
+	Limits *FunctionResources `yaml:"limits,omitempty"`
 
 	// Requests of resources requested by function
-	Requests *FunctionResources `yaml:"requests"`
+	Requests *FunctionResources `yaml:"requests,omitempty"`
 
 	// ReadOnlyRootFilesystem is used to set the container filesystem to read-only
-	ReadOnlyRootFilesystem bool `yaml:"readonly_root_filesystem"`
+	ReadOnlyRootFilesystem bool `yaml:"readonly_root_filesystem,omitempty"`
 
 	// BuildOptions to determine native packages
-	BuildOptions []string `yaml:"build_options"`
+	BuildOptions []string `yaml:"build_options,omitempty"`
 
 	// Annotations
-	Annotations *map[string]string `yaml:"annotations"`
+	Annotations *map[string]string `yaml:"annotations,omitempty"`
 
 	// Namespace of the function
 	Namespace string `yaml:"namespace,omitempty"`
+
+	// BuildArgs for providing build-args
+	BuildArgs map[string]string `yaml:"build_args,omitempty"`
+}
+
+// Configuration for the stack.yml file
+type Configuration struct {
+	StackConfig StackConfiguration `yaml:"configuration"`
+}
+
+// StackConfiguration for the overall stack.yml
+type StackConfiguration struct {
+	TemplateConfigs []TemplateSource `yaml:"templates"`
+	// CopyExtraPaths specifies additional paths (relative to the stack file) that will be copied
+	// into the functions build context, e.g. specifying `"common"` will look for and copy the
+	// "common/" folder of file in the same root as the stack file.  All paths must be contained
+	// within the project root defined by the location of the stack file.
+	//
+	// The yaml uses the shorter name `copy` to make it easier for developers to read and use
+	CopyExtraPaths []string `yaml:"copy"`
+}
+
+// TemplateSource for build templates
+type TemplateSource struct {
+	Name   string `yaml:"name"`
+	Source string `yaml:"source,omitempty"`
 }
 
 // FunctionResources Memory and CPU
@@ -74,20 +101,24 @@ type EnvironmentFile struct {
 
 // Services root level YAML file to define FaaS function-set
 type Services struct {
-	Version   string              `yaml:"version,omitempty"`
-	Functions map[string]Function `yaml:"functions,omitempty"`
-	Provider  Provider            `yaml:"provider,omitempty"`
+	Version            string              `yaml:"version,omitempty"`
+	Functions          map[string]Function `yaml:"functions,omitempty"`
+	Provider           Provider            `yaml:"provider,omitempty"`
+	StackConfiguration StackConfiguration  `yaml:"configuration,omitempty"`
 }
 
 // LanguageTemplate read from template.yml within root of a language template folder
 type LanguageTemplate struct {
-	Language     string        `yaml:"language"`
-	FProcess     string        `yaml:"fprocess"`
-	BuildOptions []BuildOption `yaml:"build_options"`
+	Language     string        `yaml:"language,omitempty"`
+	FProcess     string        `yaml:"fprocess,omitempty"`
+	BuildOptions []BuildOption `yaml:"build_options,omitempty"`
 	// WelcomeMessage is printed to the user after generating a function
-	WelcomeMessage string `yaml:"welcome_message"`
+	WelcomeMessage string `yaml:"welcome_message,omitempty"`
+	// HandlerFolder to copy the function code into
+	HandlerFolder string `yaml:"handler_folder,omitempty"`
 }
 
+// BuildOption a named build option for one or more packages
 type BuildOption struct {
 	Name     string   `yaml:"name"`
 	Packages []string `yaml:"packages"`

--- a/git-tar/vendor/github.com/openfaas/faas-cli/stack/stack.go
+++ b/git-tar/vendor/github.com/openfaas/faas-cli/stack/stack.go
@@ -18,8 +18,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const providerName = "faas"
-const providerNameLong = "openfaas"
+const legacyProviderName = "faas"
+const providerName = "openfaas"
 const defaultSchemaVersion = "1.0"
 
 // ValidSchemaVersions available schema versions
@@ -94,8 +94,8 @@ func ParseYAMLData(fileData []byte, regex string, filter string, envsubst bool) 
 		}
 	}
 
-	if services.Provider.Name != providerName && services.Provider.Name != providerNameLong {
-		return nil, fmt.Errorf("['%s', '%s'] is the only valid provider for this tool - found: %s", providerName, providerNameLong, services.Provider.Name)
+	if services.Provider.Name != providerName {
+		return nil, fmt.Errorf(`['%s'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: %s`, providerName, services.Provider.Name)
 	}
 
 	if len(services.Version) > 0 && !IsValidSchemaVersion(services.Version) {

--- a/git-tar/vendor/github.com/ryanuber/go-glob/go.mod
+++ b/git-tar/vendor/github.com/ryanuber/go-glob/go.mod
@@ -1,0 +1,1 @@
+module github.com/ryanuber/go-glob

--- a/of-builder/Dockerfile
+++ b/of-builder/Dockerfile
@@ -1,6 +1,7 @@
-FROM golang:1.11-alpine AS builder
+FROM golang:1.13-alpine AS builder
 
 ENV CGO_ENABLED=0
+ENV GO111MODULE=off
 
 RUN apk add --no-cache git g++ linux-headers curl ca-certificates
 
@@ -16,8 +17,7 @@ ADD vendor      vendor
 
 RUN go build -o /usr/bin/of-builder .
 
-FROM alpine:3.10
-
+FROM alpine:3.12
 RUN apk add --no-cache ca-certificates
 
 # Setting the group prevented access to /tmp at runtime

--- a/of-builder/README.md
+++ b/of-builder/README.md
@@ -94,7 +94,7 @@ The builder service calls into the buildkit daemon to build an OpenFaaS function
 ### Build
 
 ```sh
-export OF_BUILDER_TAG=0.7.2
+export OF_BUILDER_TAG=0.8.0
 
 make build push
 ```
@@ -102,7 +102,7 @@ make build push
 ### Deploy
 
 ```sh
-export OF_BUILDER_TAG=0.7.2
+export OF_BUILDER_TAG=0.8.0
 
 docker service create \
  --network func_functions \

--- a/stack.yml
+++ b/stack.yml
@@ -59,7 +59,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.17.3
+    image: functions/of-git-tar:0.18.0
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

Add support for limited build-args

Support for go modules is now active in git-tar and of-builder.

Fixes: #652

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on the community cluster with new images and the
following sample repo:

https://github.com/alexellis/gitops-webinar

## How are existing users impacted? What migration steps/scripts do we need?

git-tar and of-builder both need an update, but they can be updated separately. A release is also required from this repo for use with ofc-bootstrap.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
