### PR TITLE
Add troubleshooting for Gitlab docs

### DIFF
--- a/docs/GITLAB.md
+++ b/docs/GITLAB.md
@@ -130,3 +130,7 @@ Your function is now deleted.
 #### Delete the project
 
 If you delete your project your function will be automatically deleted from the cloud.
+
+#### Troubleshooting
+
+There are some usernames that don't conform to the buildkit and Kubernetes naming for secrets, (We use usernames for namespacing objects) - You may see `invalid reference format` in the buildkit logs - if you do there are github issues [here](https://github.com/openfaas/openfaas-cloud/issues/657) and [here](https://github.com/openfaas/openfaas-cloud/issues/644) where you can see what you need to change for things to work well with Gitlab.


### PR DESCRIPTION
Clarify that some usernames that are valid in gitlab are not
compatible with OpenFaaS Cloud due to the namespacing by username.

Signed-off-by: Alistair Hey <alistair.hey@form3.tech>

## Description
clarification for #657 and #644

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Docs changes

## How are existing users impacted? What migration steps/scripts do we need?
Docs changes


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
