### PR TITLE
Upgrade derek dependency to 0.10.2

### DIFF
--- a/buildshiprun/Gopkg.lock
+++ b/buildshiprun/Gopkg.lock
@@ -93,6 +93,7 @@
   input-imports = [
     "github.com/alexellis/hmac",
     "github.com/openfaas/faas-cli/proxy",
+    "github.com/openfaas/faas-cli/stack",
     "github.com/openfaas/openfaas-cloud/sdk",
   ]
   solver-name = "gps-cdcl"

--- a/buildshiprun/Gopkg.toml
+++ b/buildshiprun/Gopkg.toml
@@ -1,12 +1,4 @@
 [[constraint]]
-  name = "github.com/alexellis/derek"
-  version = "0.5.0"
-
-[[constraint]]
-  name = "github.com/google/go-github"
-  version = "15.0.0"
-
-[[constraint]]
   name = "github.com/openfaas/openfaas-cloud"
   version = "0.13.3"
 

--- a/git-tar/Gopkg.lock
+++ b/git-tar/Gopkg.lock
@@ -10,12 +10,12 @@
   revision = "2aa6f33b730c79971cfc3c742f279195b0abc627"
 
 [[projects]]
-  digest = "1:870b3bdb112ed9edf6b44673517004654384f7be83b0834c7a9a7203f2cd01fd"
+  digest = "1:61f1d9e851534a1d5881efdb940794f3ad8a8553d9a942aef66ff092b26faa83"
   name = "github.com/alexellis/derek"
   packages = ["auth"]
   pruneopts = "UT"
-  revision = "852193f67a38f5613db9b83e9f4e4e0b139aae41"
-  version = "0.9.1"
+  revision = "b453a7326b674d6ee0d413fac7c39548c3614151"
+  version = "0.10.2"
 
 [[projects]]
   digest = "1:871b7cfa5fe18bfdbd4bf117c166c3cff8d3b61c8afe4e998b5b8ac0c160ca24"

--- a/git-tar/Gopkg.toml
+++ b/git-tar/Gopkg.toml
@@ -12,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/alexellis/derek"
-  version = "0.9.1"
+  version = "0.10.2"
 
 [[override]]
   name = "gopkg.in/yaml.v2"

--- a/git-tar/vendor/github.com/alexellis/derek/auth/jwt_auth.go
+++ b/git-tar/vendor/github.com/alexellis/derek/auth/jwt_auth.go
@@ -13,6 +13,55 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
+// JWTAuth token issued by Github in response to signed JWT Token
+type JWTAuth struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// MakeAccessTokenForInstallation makes an access token for an installation / private key
+func MakeAccessTokenForInstallation(appID string, installation int, privateKey string) (string, error) {
+	signed, err := GetSignedJwtToken(appID, privateKey)
+
+	if err != nil {
+		msg := fmt.Sprintf("can't run GetSignedJwtToken for app_id: %s and installation_id: %d, error: %v", appID, installation, err)
+
+		fmt.Printf("Error %s\n", msg)
+		return "", err
+	}
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", installation), nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", signed))
+	req.Header.Add("Accept", "application/vnd.github.machine-man-preview+json")
+
+	res, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		msg := fmt.Sprintf("can't get access_token for app_id: %s and installation_id: %d error: %v", appID, installation, err)
+		fmt.Printf("Error: %s\n", msg)
+		return "", fmt.Errorf("%s", msg)
+	}
+
+	defer res.Body.Close()
+
+	bytesOut, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		return "", readErr
+	}
+
+	jwtAuth := JWTAuth{}
+	jsonErr := json.Unmarshal(bytesOut, &jwtAuth)
+	if jsonErr != nil {
+		return "", jsonErr
+	}
+	return jwtAuth.Token, nil
+}
+
 // GetSignedJwtToken get a tokens signed with private key
 func GetSignedJwtToken(appID string, privateKey string) (string, error) {
 
@@ -38,43 +87,4 @@ func GetSignedJwtToken(appID string, privateKey string) (string, error) {
 	}
 
 	return string(signedVal), nil
-}
-
-// JWTAuth token issued by Github in response to signed JWT Token
-type JWTAuth struct {
-	Token     string    `json:"token"`
-	ExpiresAt time.Time `json:"expires_at"`
-}
-
-// MakeAccessTokenForInstallation makes an access token for an installation / private key
-func MakeAccessTokenForInstallation(appID string, installation int, privateKey string) (string, error) {
-	signed, err := GetSignedJwtToken(appID, privateKey)
-
-	if err == nil {
-		c := http.Client{}
-		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("https://api.github.com/installations/%d/access_tokens", installation), nil)
-
-		req.Header.Add("Authorization", "Bearer "+signed)
-		req.Header.Add("Accept", "application/vnd.github.machine-man-preview+json")
-
-		res, err := c.Do(req)
-
-		if err == nil {
-			defer res.Body.Close()
-			bytesOut, readErr := ioutil.ReadAll(res.Body)
-			if readErr != nil {
-				return "", readErr
-			}
-
-			jwtAuth := JWTAuth{}
-			jsonErr := json.Unmarshal(bytesOut, &jwtAuth)
-			if jsonErr != nil {
-				return "", jsonErr
-			}
-
-			return string(jwtAuth.Token), nil
-		}
-	}
-
-	return "", err
 }

--- a/github-status/Gopkg.lock
+++ b/github-status/Gopkg.lock
@@ -2,15 +2,16 @@
 
 
 [[projects]]
-  digest = "1:dded960d3aa1f4479adddab5c94444f9a57ba32bb2c58655dc7eefcd8496bbb4"
+  digest = "1:7bfdc4646f8ec270a72a078719ef0f5ca551186d9343e99ee9d0efe51b3f6dd8"
   name = "github.com/alexellis/derek"
   packages = [
     "auth",
+    "config",
     "factory",
   ]
   pruneopts = "UT"
-  revision = "f8c2d49fd14b3e913c56ad2bd37193775836e906"
-  version = "0.6.1"
+  revision = "b453a7326b674d6ee0d413fac7c39548c3614151"
+  version = "0.10.2"
 
 [[projects]]
   digest = "1:871b7cfa5fe18bfdbd4bf117c166c3cff8d3b61c8afe4e998b5b8ac0c160ca24"
@@ -111,6 +112,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/alexellis/derek/auth",
+    "github.com/alexellis/derek/config",
     "github.com/alexellis/derek/factory",
     "github.com/alexellis/hmac",
     "github.com/google/go-github/github",

--- a/github-status/Gopkg.toml
+++ b/github-status/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/alexellis/derek"
-  version = "0.6.1"
+  version = "0.10.2"
 
 [[constraint]]
   name = "github.com/alexellis/hmac"

--- a/github-status/vendor/github.com/alexellis/derek/auth/customers.go
+++ b/github-status/vendor/github.com/alexellis/derek/auth/customers.go
@@ -32,10 +32,8 @@ func buildCustomerURL() string {
 // IsCustomer returns true if a customer is listed in the customers file.
 // The validation is controlled by the 'validate_customers' env-var
 func IsCustomer(ownerLogin string, c *http.Client) (bool, error) {
-	validate := os.Getenv("validate_customers")
-
-	if len(validate) == 0 || (validate == "false" || validate == "0") {
-
+	validate := customerValidationEnabled()
+	if validate == false {
 		return true, nil
 	}
 
@@ -75,4 +73,9 @@ func IsCustomer(ownerLogin string, c *http.Client) (bool, error) {
 DO_RETURN:
 
 	return found, err
+}
+
+func customerValidationEnabled() bool {
+	validate := os.Getenv("validate_customers")
+	return validate != "false" && validate != "0"
 }

--- a/github-status/vendor/github.com/alexellis/derek/auth/jwt_auth.go
+++ b/github-status/vendor/github.com/alexellis/derek/auth/jwt_auth.go
@@ -13,13 +13,59 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
-// GetSignedJwtToken get a tokens signed with private key
-func GetSignedJwtToken(appID string, privateKeyPath string) (string, error) {
+// JWTAuth token issued by Github in response to signed JWT Token
+type JWTAuth struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
 
-	keyBytes, err := ioutil.ReadFile(privateKeyPath)
+// MakeAccessTokenForInstallation makes an access token for an installation / private key
+func MakeAccessTokenForInstallation(appID string, installation int, privateKey string) (string, error) {
+	signed, err := GetSignedJwtToken(appID, privateKey)
+
 	if err != nil {
-		return "", fmt.Errorf("unable to read private key path: %s, error: %s", privateKeyPath, err)
+		msg := fmt.Sprintf("can't run GetSignedJwtToken for app_id: %s and installation_id: %d, error: %v", appID, installation, err)
+
+		fmt.Printf("Error %s\n", msg)
+		return "", err
 	}
+
+	req, err := http.NewRequest(http.MethodPost,
+		fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", installation), nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", signed))
+	req.Header.Add("Accept", "application/vnd.github.machine-man-preview+json")
+
+	res, err := http.DefaultClient.Do(req)
+
+	if err != nil {
+		msg := fmt.Sprintf("can't get access_token for app_id: %s and installation_id: %d error: %v", appID, installation, err)
+		fmt.Printf("Error: %s\n", msg)
+		return "", fmt.Errorf("%s", msg)
+	}
+
+	defer res.Body.Close()
+
+	bytesOut, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		return "", readErr
+	}
+
+	jwtAuth := JWTAuth{}
+	jsonErr := json.Unmarshal(bytesOut, &jwtAuth)
+	if jsonErr != nil {
+		return "", jsonErr
+	}
+	return jwtAuth.Token, nil
+}
+
+// GetSignedJwtToken get a tokens signed with private key
+func GetSignedJwtToken(appID string, privateKey string) (string, error) {
+
+	keyBytes := []byte(privateKey)
 
 	key, keyErr := jwt.ParseRSAPrivateKeyFromPEM(keyBytes)
 	if keyErr != nil {
@@ -41,42 +87,4 @@ func GetSignedJwtToken(appID string, privateKeyPath string) (string, error) {
 	}
 
 	return string(signedVal), nil
-}
-
-// JwtAuth token issued by Github in response to signed JWT Token
-type JwtAuth struct {
-	Token     string    `json:"token"`
-	ExpiresAt time.Time `json:"expires_at"`
-}
-
-// MakeAccessTokenForInstallation makes an access token for an installation / private key
-func MakeAccessTokenForInstallation(appID string, installation int, privateKeyPath string) (string, error) {
-	signed, err := GetSignedJwtToken(appID, privateKeyPath)
-
-	if err == nil {
-		c := http.Client{}
-		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("https://api.github.com/installations/%d/access_tokens", installation), nil)
-
-		req.Header.Add("Authorization", "Bearer "+signed)
-		req.Header.Add("Accept", "application/vnd.github.machine-man-preview+json")
-
-		res, err := c.Do(req)
-
-		if err == nil {
-			defer res.Body.Close()
-			bytesOut, readErr := ioutil.ReadAll(res.Body)
-			if readErr != nil {
-				return "", readErr
-			}
-			jwtAuth := JwtAuth{}
-			jsonErr := json.Unmarshal(bytesOut, &jwtAuth)
-			if jsonErr != nil {
-				return "", jsonErr
-			}
-
-			return string(jwtAuth.Token), nil
-		}
-	}
-
-	return "", err
 }

--- a/github-status/vendor/github.com/alexellis/derek/config/config.go
+++ b/github-status/vendor/github.com/alexellis/derek/config/config.go
@@ -1,0 +1,83 @@
+// Package config loads configuration from files and environment
+// for Derek to use
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+const (
+	derekSecretKeyFile = "derek-secret-key"
+	privateKeyFile     = "derek-private-key"
+)
+
+// Config to run Derek
+type Config struct {
+	SecretKey     string
+	PrivateKey    string
+	ApplicationID string
+}
+
+// NewConfig populates configuration from known-locations and gives
+// an error if configuration is missing from disk or environmental variables
+func NewConfig() (Config, error) {
+	config := Config{}
+
+	keyPath, pathErr := getSecretPath()
+	if pathErr != nil {
+		return config, pathErr
+	}
+
+	secretKeyBytes, readErr := ioutil.ReadFile(path.Join(keyPath, derekSecretKeyFile))
+
+	if readErr != nil {
+		msg := fmt.Errorf("unable to read GitHub symmetrical secret: %s, error: %s",
+			keyPath+derekSecretKeyFile, readErr)
+		return config, msg
+	}
+
+	secretKeyBytes = getFirstLine(secretKeyBytes)
+	config.SecretKey = string(secretKeyBytes)
+
+	privateKeyPath := path.Join(keyPath, privateKeyFile)
+
+	keyBytes, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		return config, fmt.Errorf("unable to read private key path: %s, error: %s", privateKeyPath, err)
+	}
+
+	config.PrivateKey = string(keyBytes)
+
+	if val, ok := os.LookupEnv("application_id"); ok && len(val) > 0 {
+		config.ApplicationID = val
+	} else {
+		return config, fmt.Errorf("application_id must be given")
+	}
+
+	// debug, _ := json.Marshal(config)
+	// fmt.Printf("Config:\n%s\n", debug)
+
+	return config, nil
+}
+
+func getSecretPath() (string, error) {
+	secretPath := os.Getenv("secret_path")
+
+	if len(secretPath) == 0 {
+		return "", fmt.Errorf("secret_path env-var not set, this should be /var/openfaas/secrets or /run/secrets")
+	}
+
+	return secretPath, nil
+}
+
+func getFirstLine(secret []byte) []byte {
+	stringSecret := string(secret)
+	if newLine := strings.Index(stringSecret, "\n"); newLine != -1 {
+		secret = secret[:newLine]
+	}
+	return secret
+}

--- a/github-status/vendor/github.com/alexellis/derek/factory/client_factory.go
+++ b/github-status/vendor/github.com/alexellis/derek/factory/client_factory.go
@@ -1,26 +1,28 @@
 // Copyright (c) Derek Author(s) 2017. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Package factory is used to generate http.Client instances
 package factory
 
 import (
 	"context"
 
+	"github.com/alexellis/derek/config"
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )
 
-// MakeClient make a HTTP client with a signed access token
-func MakeClient(ctx context.Context, accessToken string) *github.Client {
+// MakeClient makes a HTTP client with a signed access token
+func MakeClient(ctx context.Context, accessToken string, config config.Config) *github.Client {
 	if len(accessToken) == 0 {
 		return github.NewClient(nil)
 	}
 
-	ts := oauth2.StaticTokenSource(
+	tokenSource := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: accessToken},
 	)
-	tc := oauth2.NewClient(ctx, ts)
+	tokenClient := oauth2.NewClient(ctx, tokenSource)
 
-	client := github.NewClient(tc)
+	client := github.NewClient(tokenClient)
 	return client
 }

--- a/stack.yml
+++ b/stack.yml
@@ -302,5 +302,3 @@ functions:
     requests:
       memory: 32Mi
       cpu: 50m
-
-


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
This version of derek includes an update to remove a soon to be depricated API endpoint on github.
Reference: https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/


This release will need the following 3 containers bumped:
```
github-status
git-tar
buildshiprun
```
note: buildshiprun wasnt using Derek for auth but had it in the Gopkg

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new OFC installation was created and the above 3x containers swapped for my own built versions. 

A deployment was then completed using a commit from a linked git repository.


## How are existing users impacted? What migration steps/scripts do we need?

Github users will need to update these 3x containers in their installations before the endpoint on github is deprecated.

```
The legacy "Create an installation access token" endpoint will be disabled at the earliest on October 1 2020.
```

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
