### PR TITLE
Fix network policy

### DIFF
--- a/chart/openfaas-cloud/templates/network-policy/ns-openfaas-net-policy.yml
+++ b/chart/openfaas-cloud/templates/network-policy/ns-openfaas-net-policy.yml
@@ -21,4 +21,8 @@ spec:
     - namespaceSelector: {}
       podSelector:
         matchLabels:
+          app.kubernetes.io/name: ingress-nginx
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
           app: nginx-ingress

--- a/chart/test/network_policy_test.go
+++ b/chart/test/network_policy_test.go
@@ -35,12 +35,14 @@ func Test_CoreNetworkPolicy_Overrides(t *testing.T) {
 }
 
 func buildCoreNetworkPolicy(coreNamespace, functionNamespace string) YamlSpec {
-	podSelector := make(map[string]string)
+	nginxSelector := make(map[string]string)
+	nginxLegacySelector := make(map[string]string)
 	emptySelector := make(map[string]string)
 	matchLabelsSystem := make(map[string]string)
 	matchLabelsFunction := make(map[string]string)
 
-	podSelector["app"] = "nginx-ingress"
+	nginxSelector["app.kubernetes.io/name"] = "ingress-nginx"
+	nginxLegacySelector["app"] = "nginx-ingress"
 	matchLabelsSystem["role"] = "openfaas-system"
 	matchLabelsFunction["role"] = functionNamespace
 
@@ -72,7 +74,13 @@ func buildCoreNetworkPolicy(coreNamespace, functionNamespace string) YamlSpec {
 					{
 						Namespace: NamespaceSelector{},
 						Pod: MatchLabelSelector{
-							MatchLabels: podSelector,
+							MatchLabels: nginxSelector,
+						},
+					},
+					{
+						Namespace: NamespaceSelector{},
+						Pod: MatchLabelSelector{
+							MatchLabels: nginxLegacySelector,
 						},
 					},
 				},

--- a/docs/README.md
+++ b/docs/README.md
@@ -230,7 +230,7 @@ kubectl apply -f ./yaml/core
 
 (Optional) Deploy NetworkPolicy. These policies set the following rules:
 * Pods in the `openfaas-fn` namespace only accept traffic from namespaces and pods that have the label `role: openfaas-system`
-* Pods in the `openfaas` namespace only accept traffic from all pods in namespaces with the label `role: openfaas-system`, pods that have the label `role: openfaas-system` in the `openfaas-fn` namespace and finally pods from any namespace that have the label `app: nginx-ingress`(this is to allow traffic from the nginx ingress controller).
+* Pods in the `openfaas` namespace only accept traffic from all pods in namespaces with the label `role: openfaas-system`, pods that have the label `role: openfaas-system` in the `openfaas-fn` namespace and finally pods from any namespace that have the label `app.kubernetes.io/name: ingress-nginx` or `app: nginx-ingress`(this is to allow traffic from the nginx ingress controller).
 
 ```
 kubectl apply -f ./yaml/network-policy

--- a/stack.yml
+++ b/stack.yml
@@ -238,6 +238,7 @@ functions:
     image: functions/audit-event:0.1.2
     labels:
       openfaas-cloud: "1"
+      role: openfaas-system
       com.openfaas.scale.zero: false
     environment_file:
       - slack.yml

--- a/yaml/network-policy/ns-openfaas-net-policy.yml
+++ b/yaml/network-policy/ns-openfaas-net-policy.yml
@@ -22,3 +22,7 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          app: nginx-ingress


### PR DESCRIPTION
## Description

Fixes #669 by giving `audit-event` access to `gateway` since echo function is the default `slack_url`.
This would need to be reflected in ofc-bootstrap's [stack.yml](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/templates/stack.yml) (as should https://github.com/openfaas/openfaas-cloud/commit/2c836f32b44dc354873f72e59f7b0f2d649704bf).

Re-adds support for legacy ingress nginx network policy label (https://github.com/openfaas/openfaas-cloud/commit/1713d3294db4ae308bd51426349acd3e12bc84a4).

## How Has This Been Tested?

Tested on k3s with calico
```
k3sup install --ip $IP --user $USER --k3s-extra-args "--flannel-backend=none --cluster-cidr=192.168.0.0/16 --no-deploy traefik"
kubectl apply -k github.com/wilsonianb/calico-k3s
```
Followed ofc-bootstrap [user guide](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md) (without [oauth](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md#use-authz-recommended)) with [network policies](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/USER_GUIDE.md#toggle-network-policies-recommended) enabled and [`openfaas_cloud_version`](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/example.init.yaml#L334) set to `0.14.1`

Used pre-release ofc-bootstrap [v0.9.6](https://github.com/openfaas-incubator/ofc-bootstrap/tree/0.9.6) with `role: openfaas-system` label added to `audit-event` in [`templates/stack.yml`](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/templates/stack.yml#L204).

GitHub events no longer time out with this PR change.

Ran helm chart tests with `go test` in `$GO_PATH/src/openfaas-cloud/chart/test/` and ran `diff` on `chart/test/tmp/openfaas-cloud/templates/network-policy/ns-openfaas-net-policy.yml` and `yaml/network-policy/ns-openfaas-net-policy.yml` files.

## How are existing users impacted? What migration steps/scripts do we need?

Should only help OpenFaaS Cloud cluster administrators who had network policies previously enabled and re-run ofc-bootstrap.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
