### PR TITLE
Allow turning off the OFC Network Policy

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -47,3 +47,4 @@ This is mainly for configuration documentation for developers wishing to use thi
 | `global.coreNamespace` | `The namespace for the core OFC components` | `openfaas` |
 | `global.functionsNamespace` | `The namespace for the User Functions` | `openfaas-fn` |
 | `global.httpProbe` | `The setting to detemine is we are using http probe or exec probe. Istio users may wish to set this to fale doe example.` | `true` |
+| `networkPolicies.enabled` | `The setting to turn on/off the deployment of the OFC Network policies` | `true` |

--- a/chart/openfaas-cloud/templates/network-policy/ns-openfaas-fn-net-policy.yml
+++ b/chart/openfaas-cloud/templates/network-policy/ns-openfaas-fn-net-policy.yml
@@ -1,3 +1,4 @@
+{{- if .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -15,3 +16,4 @@ spec:
     - podSelector:
         matchLabels:
           role: openfaas-system
+{{- end }}

--- a/chart/openfaas-cloud/templates/network-policy/ns-openfaas-net-policy.yml
+++ b/chart/openfaas-cloud/templates/network-policy/ns-openfaas-net-policy.yml
@@ -1,3 +1,4 @@
+{{- if .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -26,3 +27,4 @@ spec:
       podSelector:
         matchLabels:
           app: nginx-ingress
+{{- end }}

--- a/chart/openfaas-cloud/values.yaml
+++ b/chart/openfaas-cloud/values.yaml
@@ -65,6 +65,10 @@ customers:
   ## indicated in the openfaas-cloud docs on customers. If you want this option, set this to true.
   customersSecret: false
 
+networkPolicies:
+  ## If true, network policies are enabled, otherwise they are not.
+  enabled: true
+
 
 ## global values that are re-used across multiple components
 global:

--- a/chart/test/network_policy_test.go
+++ b/chart/test/network_policy_test.go
@@ -4,6 +4,15 @@ import (
 	"testing"
 )
 
+func Test_YamlSpec_NoNW_Policies(t *testing.T){
+	parts := []string{
+		"--set", "networkPolicies.enabled=false",
+	}
+	runYamlTestNoFileExpected(parts, "./tmp/openfaas-cloud/templates/network-policy/ns-openfaas-fn-net-policy.yml", t)
+	runYamlTestNoFileExpected(parts, "./tmp/openfaas-cloud/templates/network-policy/ns-openfaas-net-policy.yml", t)
+
+}
+
 func Test_YamlSpecFNNamespace_NoOverrides(t *testing.T) {
 	parts := []string{}
 	want := buildFnNetworkPolicy("openfaas-fn")

--- a/chart/test/tools.go
+++ b/chart/test/tools.go
@@ -3,6 +3,7 @@ package test
 import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -92,5 +93,20 @@ func runYamlTest(parts []string, filename string, want YamlSpec, t *testing.T) {
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("got:\n%+v\nbut want:\n%+v", got, want)
 		t.Fail()
+	}
+}
+
+func runYamlTestNoFileExpected(parts []string, filename string, t *testing.T) {
+	os.RemoveAll("./tmp")
+	_, _ = helmRunner(parts...)
+
+	_, err := ioutil.ReadFile(filename)
+
+	if err == nil {
+		t.Errorf("Expected file not to exist, got a file: %s", filename)
+	}
+
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected file not to exist, got err: %v", err)
 	}
 }

--- a/chart/test/values.yml
+++ b/chart/test/values.yml
@@ -11,6 +11,9 @@ customers:
 global:
   rootDomain: example.com
 
+networkPolicies:
+  enabled: true
+
 tls:
   enabled: false
   dnsService: fake


### PR DESCRIPTION
## Description
This Fixes #675 by allowing the NetworkPolicies to be turned off in the
chart installation

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Chart tests written

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
