### PR TITLE
Remove redundant setting for scheme in chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -38,7 +38,6 @@ This is mainly for configuration documentation for developers wishing to use thi
 | `customers.url` | `The public URL to a customers file, it should be unformatted with 1 username per line` | `""` |
 | `customers.customersSecret` | `If set to ture we use a secret for our customers list rather than a public URL` | `false` |
 | `global.rootDomain` | `The root domain for this OFC installation` | `"example.com"` |
-| `global.scheme` | `Wither http or https, depending on the TLS setting` | `https` |
 | `global.enableECR` | `Set to true is using ECR as our container registry rather than Docker Hub` | `false` |
 | `global.imagePullPolicy` | `The policy for pulling OFC images, Allways or IfNotPresent for example` | `IfNotPresent` |
 | `global.coreNamespace` | `The namespace for the core OFC components` | `openfaas` |

--- a/chart/openfaas-cloud/templates/ofc-core/edge-auth-dep.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/edge-auth-dep.yaml
@@ -77,7 +77,11 @@ spec:
             - name: oauth_provider
               value: {{ .Values.edgeAuth.oauthProvider | quote }}
             - name: external_redirect_domain
-              value: {{ printf "%s://auth.system.%s" .Values.global.scheme .Values.global.rootDomain | quote }}
+              {{- if .Values.tls.enabled }}
+              value: {{ printf "https://auth.system.%s" .Values.global.rootDomain | quote }}
+              {{- else }}
+              value: {{ printf "http://auth.system.%s" .Values.global.rootDomain | quote }}
+              {{- end }}
             - name: cookie_root_domain
               value: {{ printf ".system.%s" .Values.global.rootDomain | quote }}
             - name: secure_cookie

--- a/chart/openfaas-cloud/values.yaml
+++ b/chart/openfaas-cloud/values.yaml
@@ -73,8 +73,6 @@ global:
 
   ## rootDomain is the root domain of the ofc installation o6s.io for example
   rootDomain: "example.com"
-  ## scheme is the http/https setting for the installation
-  scheme: https
   enableECR: false
   imagePullPolicy: IfNotPresent
   ## coreNamespace this is used where we need to communicate with core openfaas components

--- a/chart/test/core_edge_auth_dep_test.go
+++ b/chart/test/core_edge_auth_dep_test.go
@@ -136,6 +136,7 @@ func makeContainerVolumes(customersSecret bool) []ContainerVolume {
 
 func makeContainerEnv(customersSecret, secureCookie bool) []Environment {
 	var environ []Environment
+
 	environ = append(environ, Environment{Name: "port", Value: "8080"})
 	environ = append(environ, Environment{Name: "oauth_client_secret_path", Value: "/var/secrets/of-client-secret/of-client-secret"})
 	environ = append(environ, Environment{Name: "public_key_path", Value: "/var/secrets/public/key.pub"})
@@ -146,7 +147,7 @@ func makeContainerEnv(customersSecret, secureCookie bool) []Environment {
 	environ = append(environ, Environment{Name: "client_id", Value: "client-id"})
 	environ = append(environ, Environment{Name: "oauth_provider_base_url", Value: ""})
 	environ = append(environ, Environment{Name: "oauth_provider", Value: "github"})
-	environ = append(environ, Environment{Name: "external_redirect_domain", Value: "https://auth.system.example.com"})
+	environ = append(environ, Environment{Name: "external_redirect_domain", Value: "http://auth.system.example.com"})
 	environ = append(environ, Environment{Name: "cookie_root_domain", Value: ".system.example.com"})
 	environ = append(environ, Environment{Name: "secure_cookie", Value: strconv.FormatBool(secureCookie)})
 	if !customersSecret {


### PR DESCRIPTION
The chart had a setting that can be derived based on another value. This
commit removed the extra config value as it is not required

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
Fixes #677 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There's unit tests

## How are existing users impacted? What migration steps/scripts do we need?

N/A

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
