### PR TITLE
Update chart namespaces to match existing

### DIFF
--- a/chart/openfaas-cloud/templates/ingress/ingress-auth.yml
+++ b/chart/openfaas-cloud/templates/ingress/ingress-auth.yml
@@ -7,6 +7,13 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/limit-connections: {{ .Values.ingress.maxConnections | quote }}
     nginx.ingress.kubernetes.io/limit-rpm: {{ .Values.ingress.requestsPerMinute | quote }}
+  {{- if .Values.tls.enabled }}
+    {{- if eq .Values.tls.issuerType "prod" }}
+    cert-manager.io/issuer: letsencrypt-prod
+    {{- else }}
+    cert-manager.io/issuer: letsencrypt-staging
+    {{- end }}
+  {{- end }}
   labels:
     app: faas-netesd
 spec:

--- a/chart/openfaas-cloud/templates/ingress/ingress-wildcard.yml
+++ b/chart/openfaas-cloud/templates/ingress/ingress-wildcard.yml
@@ -7,6 +7,13 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
     nginx.ingress.kubernetes.io/limit-connections: {{ .Values.ingress.maxConnections | quote }}
     nginx.ingress.kubernetes.io/limit-rpm: {{ .Values.ingress.requestsPerMinute | quote }}
+    {{- if .Values.tls.enabled }}
+    {{- if eq .Values.tls.issuerType "prod" }}
+    cert-manager.io/issuer: letsencrypt-prod
+      {{- else }}
+    cert-manager.io/issuer: letsencrypt-staging
+    {{- end }}
+    {{- end }}
   labels:
     app: faas-netesd
 spec:

--- a/chart/openfaas-cloud/templates/ofc-core/edge-auth-dep.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/edge-auth-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: edge-auth
+  namespace: {{ .Values.global.coreNamespace }}
   labels:
     app.kubernetes.io/name: openfaas-cloud
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/chart/openfaas-cloud/templates/ofc-core/edge-auth-svc.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/edge-auth-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: edge-auth
+  namespace: {{ .Values.global.coreNamespace }}
   labels:
     app: edge-auth
 spec:

--- a/chart/openfaas-cloud/templates/ofc-core/edge-router-dep.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/edge-router-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: edge-router
+  namespace: {{ .Values.global.coreNamespace }}
   labels:
     app.kubernetes.io/name: openfaas-cloud
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/chart/openfaas-cloud/templates/ofc-core/edge-router-svc.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/edge-router-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: edge-router
+  namespace: {{ .Values.global.coreNamespace }}
   labels:
     app: edge-router
 spec:

--- a/chart/openfaas-cloud/templates/ofc-core/of-builder-dep.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/of-builder-dep.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: of-builder
+  namespace: {{ .Values.global.coreNamespace }}
   labels:
     app.kubernetes.io/name: openfaas-cloud
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/chart/openfaas-cloud/templates/ofc-core/of-builder-svc.yaml
+++ b/chart/openfaas-cloud/templates/ofc-core/of-builder-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: of-builder
+  namespace: {{ .Values.global.coreNamespace }}
   labels:
     app: of-builder
 spec:

--- a/chart/openfaas-cloud/templates/tls/issuer-prod.yml
+++ b/chart/openfaas-cloud/templates/tls/issuer-prod.yml
@@ -1,6 +1,6 @@
 {{- if .Values.tls.enabled }}
 apiVersion: cert-manager.io/v1alpha2
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: letsencrypt-prod
   namespace: {{ .Values.global.coreNamespace }}

--- a/chart/openfaas-cloud/templates/tls/issuer-staging.yml
+++ b/chart/openfaas-cloud/templates/tls/issuer-staging.yml
@@ -1,6 +1,6 @@
 {{- if .Values.tls.enabled }}
 apiVersion: cert-manager.io/v1alpha2
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: letsencrypt-staging
   namespace: {{ .Values.global.coreNamespace }}

--- a/chart/test/core_edge_auth_dep_test.go
+++ b/chart/test/core_edge_auth_dep_test.go
@@ -72,6 +72,7 @@ func makeEdgeAuthDep(httpProbe, customersSecret, secureCookie bool) YamlSpec {
 		Kind:       "Deployment",
 		Metadata: MetadataItems{
 			Name:   "edge-auth",
+			Namespace: "openfaas",
 			Labels: labels,
 		},
 		Spec: Spec{
@@ -86,7 +87,7 @@ func makeEdgeAuthDep(httpProbe, customersSecret, secureCookie bool) YamlSpec {
 					Volumes: deployVolumes,
 					Containers: []DeploymentContainers{{
 						Name:                    "edge-auth",
-						Image:                   "openfaas/edge-auth:0.7.0",
+						Image:                   "openfaas/edge-auth:0.8.0",
 						ImagePullPolicy:         "IfNotPresent",
 						ContainerReadinessProbe: livenessProbe,
 						ContainerEnvironment:    containerEnvironment,

--- a/chart/test/core_edge_router_dep_test.go
+++ b/chart/test/core_edge_router_dep_test.go
@@ -80,6 +80,7 @@ func makeEdgeRouterDep(httpProbe, oauthEnabled bool) YamlSpec {
 		Kind:       "Deployment",
 		Metadata: MetadataItems{
 			Name:   "edge-router",
+			Namespace: "openfaas",
 			Labels: labels,
 		},
 		Spec: Spec{

--- a/chart/test/core_of_builder_dep_test.go
+++ b/chart/test/core_of_builder_dep_test.go
@@ -54,6 +54,7 @@ func makeOFBuilderDep(httpProbe, isECR bool, replicas int, buildkitPrivileged, o
 		Kind:       "Deployment",
 		Metadata: MetadataItems{
 			Name:   "of-builder",
+			Namespace: "openfaas",
 			Labels: labels,
 		},
 		Spec: Spec{

--- a/chart/test/ingress_test.go
+++ b/chart/test/ingress_test.go
@@ -98,6 +98,9 @@ func buildIngressAuth(hostDomain, prefix, name, ingressClass, rpm, maxConnection
 	annotations["kubernetes.io/ingress.class"] = ingressClass
 	annotations["nginx.ingress.kubernetes.io/limit-connections"] = maxConnections
 	annotations["nginx.ingress.kubernetes.io/limit-rpm"] = rpm
+	if tls {
+		annotations["cert-manager.io/issuer"] = "letsencrypt-staging"
+	}
 
 	spec := Spec{
 		Rules: []SpecRules{{

--- a/chart/test/tls_issuer_prod_test.go
+++ b/chart/test/tls_issuer_prod_test.go
@@ -143,7 +143,7 @@ func makeIssuer(tlsSettings TLSSettings, coreNamespace, issuerName string) YamlS
 
 	return YamlSpec{
 		ApiVersion: "cert-manager.io/v1alpha2",
-		Kind:       "ClusterIssuer",
+		Kind:       "Issuer",
 		Metadata: MetadataItems{
 			Name:        issuerName,
 			Namespace:   coreNamespace,

--- a/chart/test/tools.go
+++ b/chart/test/tools.go
@@ -18,6 +18,7 @@ func serviceBuilder(svcName, svcType string, srcPort, targetPort int) SvcSpec {
 		Kind:       "Service",
 		Metadata: MetadataItems{
 			Name:   svcName,
+			Namespace: "openfaas",
 			Labels: labelMap,
 		},
 		Spec: MapSpec{


### PR DESCRIPTION
## Description
The namespaces in the chart were wrong or missing for a lot of
the resources. These have now been corrected along with adding the
annotation for ingress shim for cert-manager to get tls for domains if
they are asked for

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>




## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
