### PR TITLE
Part one of converting OFC to go modules

### DIFF
--- a/audit-event/go.mod
+++ b/audit-event/go.mod
@@ -1,0 +1,11 @@
+module github.com/openfaas/openfaas-cloud/audit-event
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/openfaas/faas-provider v0.0.0-20191011092439-98c25c3919da
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	github.com/sirupsen/logrus v1.7.0
+	golang.org/x/sys v0.0.0-20201109165425-215b40eba54c
+)

--- a/buildshiprun/go.mod
+++ b/buildshiprun/go.mod
@@ -1,0 +1,15 @@
+module github.com/openfaas/openfaas-cloud/buildshiprun
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/drone/envsubst v1.0.2
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/openfaas/faas v0.0.0-20200305154109-326cc7a9b923
+	github.com/openfaas/faas-cli v0.0.0-20200226083118-b0a70a3f4f20
+	github.com/openfaas/faas-provider v0.0.0-20191005090653-478f741b64cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	github.com/ryanuber/go-glob v1.0.0
+	gopkg.in/yaml.v2 v2.2.8
+)

--- a/edge-auth/go.mod
+++ b/edge-auth/go.mod
@@ -1,0 +1,10 @@
+module github.com/openfaas/openfaas-cloud/edge-auth
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/openfaas/faas-provider v0.0.0-20191011092439-98c25c3919da
+	github.com/openfaas/openfaas-cloud v0.0.0-20200225145041-6a94566a9f09
+)

--- a/edge-router/go.mod
+++ b/edge-router/go.mod
@@ -1,0 +1,3 @@
+module github.com/openfaas/openfaas-cloud/edge-router
+
+go 1.13

--- a/function-logs/go.mod
+++ b/function-logs/go.mod
@@ -1,0 +1,15 @@
+module github.com/openfaas/openfaas-cloud/function-logs
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/drone/envsubst v1.0.2
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/openfaas/faas v0.0.0-20200312140257-f6526929665c
+	github.com/openfaas/faas-cli v0.0.0-20200226083118-b0a70a3f4f20
+	github.com/openfaas/faas-provider v0.0.0-20191005090653-478f741b64cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	github.com/ryanuber/go-glob v1.0.0
+	gopkg.in/yaml.v2 v2.2.8
+)

--- a/garbage-collect/go.mod
+++ b/garbage-collect/go.mod
@@ -1,0 +1,15 @@
+module github.com/openfaas/openfaas-cloud/garbage-collect
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624211220-5c52ab81c0de
+	github.com/drone/envsubst v1.0.2
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/openfaas/faas v0.0.0-20200305154109-326cc7a9b923
+	github.com/openfaas/faas-cli v0.0.0-20200226083118-b0a70a3f4f20
+	github.com/openfaas/faas-provider v0.0.0-20191005090653-478f741b64cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	github.com/ryanuber/go-glob v1.0.0
+	gopkg.in/yaml.v2 v2.2.8
+)

--- a/git-tar/go.mod
+++ b/git-tar/go.mod
@@ -1,0 +1,16 @@
+module github.com/openfaas/openfaas-cloud/git-tar
+
+go 1.13
+
+require (
+	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c
+	github.com/alexellis/derek v0.0.0-20200824120721-b453a7326b67
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/drone/envsubst v1.0.2
+	github.com/openfaas/faas-cli v0.0.0-20200701205053-16f6eb9522cf
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	github.com/ryanuber/go-glob v1.0.0
+	gopkg.in/yaml.v2 v2.2.4
+)

--- a/github-event/go.mod
+++ b/github-event/go.mod
@@ -1,0 +1,9 @@
+module github.com/openfaas/openfaas-cloud/github-event
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624211220-5c52ab81c0de
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+)

--- a/github-push/go.mod
+++ b/github-push/go.mod
@@ -1,0 +1,9 @@
+module github.com/openfaas/openfaas-cloud/github-push
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624211220-5c52ab81c0de
+	github.com/openfaas/faas-provider v0.0.0-20181216160432-220324e98f5d
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+)

--- a/github-status/go.mod
+++ b/github-status/go.mod
@@ -1,0 +1,17 @@
+module github.com/openfaas/openfaas-cloud/github-status
+
+go 1.13
+
+require (
+	github.com/alexellis/derek v0.0.0-20200824120721-b453a7326b67
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang/protobuf v1.2.0
+	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135
+	github.com/openfaas/faas-provider v0.0.0-20181216160432-220324e98f5d
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
+	google.golang.org/appengine v1.1.0
+)

--- a/gitlab-event/go.mod
+++ b/gitlab-event/go.mod
@@ -1,0 +1,9 @@
+module github.com/openfaas/openfaas-cloud/gitlab-event
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+)

--- a/gitlab-push/go.mod
+++ b/gitlab-push/go.mod
@@ -1,0 +1,9 @@
+module github.com/openfaas/openfaas-cloud/gitlab-push
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+)

--- a/gitlab-status/go.mod
+++ b/gitlab-status/go.mod
@@ -1,0 +1,9 @@
+module github.com/openfaas/openfaas-cloud/gitlab-status
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/openfaas/openfaas-cloud
+
+go 1.13

--- a/import-secrets/go.mod
+++ b/import-secrets/go.mod
@@ -1,0 +1,33 @@
+module github.com/openfaas/openfaas-cloud/import-secrets
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/bitnami-labs/sealed-secrets v0.9.8
+	github.com/davecgh/go-spew v1.1.1
+	github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415
+	github.com/golang/protobuf v1.3.4
+	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
+	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be
+	github.com/mkmik/multierror v0.3.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
+	github.com/openfaas/faas-provider v0.0.0-20191011092439-98c25c3919da
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+	golang.org/x/crypto v0.0.0-20181025213731-e84da0312774
+	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
+	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
+	golang.org/x/sys v0.0.0-20190209173611-3b5209105503
+	golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db
+	golang.org/x/time v0.0.0-20161028155119-f51c12702a4d
+	google.golang.org/appengine v1.6.5
+	gopkg.in/inf.v0 v0.9.1
+	gopkg.in/yaml.v2 v2.2.8
+	k8s.io/api v0.15.10
+	k8s.io/apimachinery v0.15.10
+	k8s.io/client-go v0.15.10
+	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20200124190032-861946025e34
+	sigs.k8s.io/yaml v1.2.0
+)

--- a/list-functions/go.mod
+++ b/list-functions/go.mod
@@ -1,0 +1,15 @@
+module github.com/openfaas/openfaas-cloud/list-functions
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/drone/envsubst v1.0.2
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/openfaas/faas v0.0.0-20200305154109-326cc7a9b923
+	github.com/openfaas/faas-cli v0.0.0-20200226083118-b0a70a3f4f20
+	github.com/openfaas/faas-provider v0.0.0-20191005090653-478f741b64cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200305165942-85f5f4991594
+	github.com/ryanuber/go-glob v1.0.0
+	gopkg.in/yaml.v2 v2.2.8
+)

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -1,0 +1,15 @@
+module github.com/openfaas/openfaas-cloud/metrics
+
+go 1.13
+
+require (
+	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
+	github.com/golang/protobuf v1.2.0
+	github.com/matttproud/golang_protobuf_extensions v1.0.1
+	github.com/openfaas/faas v0.0.0-20191227175319-80b6976c1063
+	github.com/openfaas/faas-provider v0.0.0-20191011092439-98c25c3919da
+	github.com/prometheus/client_golang v0.8.0
+	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
+	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e
+	github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273
+)

--- a/of-builder/go.mod
+++ b/of-builder/go.mod
@@ -1,0 +1,41 @@
+module github.com/openfaas/openfaas-cloud/of-builder
+
+go 1.13
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+	github.com/Microsoft/go-winio v0.4.7
+	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/containerd/continuity v0.0.0-20180416230128-c6cef3483023
+	github.com/docker/cli v0.0.0-20180503173406-0ff5f5205159
+	github.com/docker/distribution v2.6.0-rc.1.0.20170825220652-30578ca32960+incompatible
+	github.com/docker/docker v1.4.2-0.20180506231517-5f395b35bc60
+	github.com/docker/docker-credential-helpers v0.6.0
+	github.com/docker/go-connections v0.3.0
+	github.com/docker/go-units v0.3.3
+	github.com/gogo/protobuf v1.0.0
+	github.com/golang/protobuf v1.1.0
+	github.com/google/shlex v0.0.0-20150127133951-6f45313302b9
+	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f
+	github.com/gorilla/mux v1.6.1
+	github.com/moby/buildkit v0.0.0-20180507051859-fabec2957873
+	github.com/opencontainers/go-digest v1.0.0-rc1
+	github.com/opencontainers/image-spec v1.0.1
+	github.com/opencontainers/runc v0.1.1
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20180927141003-6abeccfcf77b
+	github.com/opentracing/opentracing-go v1.0.2
+	github.com/pkg/errors v0.8.0
+	github.com/sirupsen/logrus v1.0.2-0.20170713114250-a3f95b5c4235
+	github.com/tonistiigi/fsutil v0.0.0-20180414035453-93a0fd10b669
+	github.com/tonistiigi/grpc-opentracing v0.0.0-20180106052059-420e5c3331a0
+	golang.org/x/net v0.0.0-20180502164142-640f4622ab69
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
+	golang.org/x/sys v0.0.0-20180504064212-6f686a352de6
+	golang.org/x/text v0.3.0
+	google.golang.org/genproto v0.0.0-20180427144745-86e600f69ee4
+	google.golang.org/grpc v1.11.3
+)
+
+replace github.com/grpc-ecosystem/grpc-opentracing 420e5c3331a082e0c873adeeab1819fe1749dd0b => github.com/tonistiigi/grpc-opentracing v0.0.0-20180106052059-420e5c3331a0

--- a/pipeline-log/go.mod
+++ b/pipeline-log/go.mod
@@ -1,0 +1,19 @@
+module github.com/openfaas/openfaas-cloud/pipeline-log
+
+go 1.13
+
+replace (
+	github.com/openfaas/openfaas-cloud/pipeline-log => /home/heyal/go/src/github.com/openfaas/openfaas-cloud/pipeline-log
+	github.com/openfaas/openfaas-cloud/sdk => /home/heyal/go/src/github.com/openfaas/openfaas-cloud/sdk
+)
+
+require (
+	github.com/minio/minio-go/v6 v6.0.57
+	github.com/openfaas/faas-provider v0.0.0-20191011092439-98c25c3919da // indirect
+	github.com/openfaas/openfaas-cloud/sdk v0.0.0-00010101000000-000000000000
+	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
+	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/ini.v1 v1.52.0 // indirect
+)

--- a/register-image/go.mod
+++ b/register-image/go.mod
@@ -1,0 +1,11 @@
+module github.com/openfaas/openfaas-cloud/register-image
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/aws/aws-sdk-go v1.25.9
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
+	github.com/openfaas/faas-provider v0.0.0-20191005090653-478f741b64cb
+	github.com/openfaas/openfaas-cloud v0.0.0-20200303103051-6c3e056a6ac4
+)

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,0 +1,8 @@
+module github.com/openfaas/openfaas-cloud/sdk
+
+go 1.13
+
+require (
+	github.com/alexellis/hmac v0.0.0-20180624210714-d5d71edd7bc7
+	github.com/openfaas/faas-provider v0.0.0-20180910095832-845bf7aa58cb
+)


### PR DESCRIPTION
## Description


This will initialise a module in each function/folder. This needs to be
merged before modules can start to manage dependancies because otherwise
you get a duplicate definition error as each function that imports
anything from the ofc repo (from github in its gopkg) will pull the
whole repo in, not just the module it wants (the SDK for example) so we
need a go mod in each folder to avoid it existing twice in the
dependency tree for the function.

Once this is in, each module can be converted to go modules and remove
the use of dep

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a replace directive for the local module on disk and tested the go mod vendor and go mod tidy calls worked and started to manage deps. Without the replace we got the errors mentioned above

## How are existing users impacted? What migration steps/scripts do we need?
no changes. This is background work to upgrade to go modules and is required to make the switch.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
