### PR TITLE
Bump chart images to MultiArch

### DIFF
--- a/chart/openfaas-cloud/Chart.yaml
+++ b/chart/openfaas-cloud/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.12.1"
+appVersion: "0.14.4"
 description: A Helm chart for some OpenFaaS Cloud components
 name: openfaas-cloud
-version: 0.12.1
+version: 0.14.4

--- a/chart/openfaas-cloud/values.yaml
+++ b/chart/openfaas-cloud/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 
 ofBuilder:
-  image: openfaas/of-builder:0.8.0
+  image: ghcr.io/openfaas/ofc-of-builder:0.14.4
   replicas: 1
 
 buildKit:
@@ -11,7 +11,7 @@ buildKit:
 
 
 edgeAuth:
-  image: openfaas/edge-auth:0.8.0
+  image: ghcr.io/openfaas/ofc-edge-auth:0.14.4
   replicas: 1
   enableOAuth2: true
   oauthProvider: github
@@ -22,7 +22,7 @@ edgeAuth:
   writeDebug: false
 
 edgeRouter:
-  image: openfaas/edge-router:0.7.4
+  image: ghcr.io/openfaas/ofc-edge-router:0.14.4
 
 tls:
   enabled: false

--- a/chart/test/core_edge_auth_dep_test.go
+++ b/chart/test/core_edge_auth_dep_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 )
@@ -35,7 +36,7 @@ func makeEdgeAuthDep(httpProbe, customersSecret, secureCookie bool) YamlSpec {
 	labels["app.kubernetes.io/instance"] = "RELEASE-NAME"
 	labels["app.kubernetes.io/managed-by"] = "Helm"
 	labels["app.kubernetes.io/name"] = "openfaas-cloud"
-	labels["helm.sh/chart"] = "openfaas-cloud-0.12.1"
+	labels["helm.sh/chart"] = fmt.Sprintf("openfaas-cloud-%s", ofcVersion)
 
 	requiredVolumes := []string{"jwt-private-key", "jwt-public-key", "of-client-secret"}
 	if customersSecret {
@@ -87,7 +88,7 @@ func makeEdgeAuthDep(httpProbe, customersSecret, secureCookie bool) YamlSpec {
 					Volumes: deployVolumes,
 					Containers: []DeploymentContainers{{
 						Name:                    "edge-auth",
-						Image:                   "openfaas/edge-auth:0.8.0",
+						Image:                   fmt.Sprintf("ghcr.io/openfaas/ofc-edge-auth:%s", ofcVersion),
 						ImagePullPolicy:         "IfNotPresent",
 						ContainerReadinessProbe: livenessProbe,
 						ContainerEnvironment:    containerEnvironment,

--- a/chart/test/core_edge_router_dep_test.go
+++ b/chart/test/core_edge_router_dep_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -50,7 +51,7 @@ func makeEdgeRouterDep(httpProbe, oauthEnabled bool) YamlSpec {
 	labels["app.kubernetes.io/instance"] = "RELEASE-NAME"
 	labels["app.kubernetes.io/managed-by"] = "Helm"
 	labels["app.kubernetes.io/name"] = "openfaas-cloud"
-	labels["helm.sh/chart"] = "openfaas-cloud-0.12.1"
+	labels["helm.sh/chart"] = fmt.Sprintf("openfaas-cloud-%s", ofcVersion)
 
 	containerEnvironment := makeRouterContainerEnv(oauthEnabled)
 
@@ -94,7 +95,7 @@ func makeEdgeRouterDep(httpProbe, oauthEnabled bool) YamlSpec {
 				Spec: TemplateSpec{
 					Containers: []DeploymentContainers{{
 						Name:                    "edge-router",
-						Image:                   "openfaas/edge-router:0.7.4",
+						Image:                   fmt.Sprintf("ghcr.io/openfaas/ofc-edge-router:%s", ofcVersion),
 						ImagePullPolicy:         "IfNotPresent",
 						ContainerReadinessProbe: readinessProbe,
 						ContainerEnvironment:    containerEnvironment,

--- a/chart/test/core_of_builder_dep_test.go
+++ b/chart/test/core_of_builder_dep_test.go
@@ -1,6 +1,9 @@
 package test
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func Test_CoreOFBuilderDep_NonHttpProbe(t *testing.T) {
 	parts := []string{
@@ -22,7 +25,7 @@ func makeOFBuilderDep(httpProbe, isECR bool, replicas int, buildkitPrivileged, o
 	labels["app.kubernetes.io/instance"] = "RELEASE-NAME"
 	labels["app.kubernetes.io/managed-by"] = "Helm"
 	labels["app.kubernetes.io/name"] = "openfaas-cloud"
-	labels["helm.sh/chart"] = "openfaas-cloud-0.12.1"
+	labels["helm.sh/chart"] = fmt.Sprintf("openfaas-cloud-%s", ofcVersion)
 
 	deployVolumes := makeOFBuilderDeployVolumes([]string{"registry-secret", "payload-secret"}, isECR)
 	containerVolumes := makeOFBuilderContainerVolumes(isECR)
@@ -69,7 +72,7 @@ func makeOFBuilderDep(httpProbe, isECR bool, replicas int, buildkitPrivileged, o
 					Volumes: deployVolumes,
 					Containers: []DeploymentContainers{{
 						Name:                    "of-builder",
-						Image:                   "openfaas/of-builder:0.8.0",
+						Image:                   fmt.Sprintf("ghcr.io/openfaas/ofc-of-builder:%s", ofcVersion),
 						ImagePullPolicy:         "IfNotPresent",
 						ContainerReadinessProbe: readinessProbe,
 						ContainerEnvironment:    containerEnvironment,

--- a/chart/test/types.go
+++ b/chart/test/types.go
@@ -1,5 +1,7 @@
 package test
 
+const ofcVersion = "0.14.4"
+
 type YamlSpec struct {
 	ApiVersion string            `yaml:"apiVersion"`
 	Kind       string            `yaml:"kind"`

--- a/chart/test/vendor/modules.txt
+++ b/chart/test/vendor/modules.txt
@@ -1,0 +1,6 @@
+# github.com/alexellis/go-execute v0.0.0-20191029181357-d17947259f74
+## explicit
+github.com/alexellis/go-execute/pkg/v1
+# gopkg.in/yaml.v2 v2.2.7
+## explicit
+gopkg.in/yaml.v2

--- a/yaml/core/edge-auth-dep.yml
+++ b/yaml/core/edge-auth-dep.yml
@@ -32,7 +32,7 @@ spec:
             secretName: of-customers
       containers:
       - name: edge-auth
-        image: openfaas/edge-auth:0.7.1
+        image: ghcr.io/openfaas/ofc-edge-auth:0.14.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/yaml/core/edge-router-dep.yml
+++ b/yaml/core/edge-router-dep.yml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: edge-router
-        image: openfaas/edge-router:0.7.5
+        image: ghcr.io/openfaas/ofc-edge-router:0.14.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/yaml/core/of-builder-dep.yml
+++ b/yaml/core/of-builder-dep.yml
@@ -28,7 +28,7 @@ spec:
             secretName: payload-secret
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.7.2
+        image: ghcr.io/openfaas/ofc-of-builder:0.14.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION

## Description
Bump the ofc chart to v 0.14.4, this includes Multi arch images, ghcr
migration and other fixes

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tests to verify changes

## How are existing users impacted? What migration steps/scripts do we need?
no change, the chart is not used by the installer yet


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
