### PR TITLE
Link to SCM and public key in dashboard

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -39,6 +39,16 @@ $ faas-cli store deploy nodeinfo --name alexellis-nodeinfo \
  --annotation com.openfaas.cloud.git-repo-url=https://github.com/alexellis/nodeinfo
 ```
 
+### Deploy SealedSecrets public key
+
+The dashboard serves the SealedSecrets public key file in `/var/openfaas/secrets/pub-cert.pem`.
+
+To mount the key in Kubernetes, run:
+
+```
+$ kubectl create secret generic sealedsecrets-public-key -n openfaas-fn --from-file=pub-cert.pem
+```
+
 ### Deploy at least the list-functions function
 
 From the root directory edit `gateway_config.yml`, if on Swarm remove any `.openfaas` suffix you see in URLs.
@@ -106,7 +116,7 @@ npm i -g yarn
 The source code for the dashboard (written in React.js) with Bootstrap 3 has to be built into a generated folder. In order to do this type in `make`
 
 ```bash
-make
+make build-dist
 ```
 
 You will see new files written into `of-cloud-dashboard/dist`

--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -20,6 +20,7 @@
     window.ALL_CLAIMS = '__ALL_CLAIMS__';
     window.GITHUB_APP_URL = '__GITHUB_APP_URL__';
     window.GITLAB_URL = '__GITLAB_URL__';
+    window.PUBLIC_KEY_EXISTS = '__PUBLIC_KEY_EXISTS__';
   </script>
 </head>
 

--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -20,7 +20,6 @@
     window.ALL_CLAIMS = '__ALL_CLAIMS__';
     window.GITHUB_APP_URL = '__GITHUB_APP_URL__';
     window.GITLAB_URL = '__GITLAB_URL__';
-    window.PUBLIC_KEY_EXISTS = '__PUBLIC_KEY_EXISTS__';
   </script>
 </head>
 

--- a/dashboard/client/public/index.html
+++ b/dashboard/client/public/index.html
@@ -17,7 +17,9 @@
     window.PUBLIC_URL = '__PUBLIC_URL__';
     window.PRETTY_URL = '__PRETTY_URL__';
     window.QUERY_PRETTY_URL = '__QUERY_PRETTY_URL__';
-    window.ALL_CLAIMS = '__ALL_CLAIMS__'
+    window.ALL_CLAIMS = '__ALL_CLAIMS__';
+    window.GITHUB_APP_URL = '__GITHUB_APP_URL__';
+    window.GITLAB_URL = '__GITLAB_URL__';
   </script>
 </head>
 

--- a/dashboard/client/src/components/NavBar/NavBar.jsx
+++ b/dashboard/client/src/components/NavBar/NavBar.jsx
@@ -118,18 +118,16 @@ class NavBarWithRouter extends Component {
                 </NavLink>
               </NavItem>
             }
-            { window.PUBLIC_KEY_EXISTS &&
-              <NavItem>
-                <NavLink
-                  className="py-3 px-3 px-md-2"
-                  href="dist/pub-cert.pem"
-                  title="Encrypt function secrets for use in your git repository"
-                >
-                  <FontAwesomeIcon icon={faKey} className="mr-1" />
-                  Public Key
-                </NavLink>
-              </NavItem>
-            }
+            <NavItem>
+              <NavLink
+                className="py-3 px-3 px-md-2"
+                href="api/pub-cert.pem"
+                title="Encrypt function secrets for use in your git repository"
+              >
+                <FontAwesomeIcon icon={faKey} className="mr-1" />
+                Public Key
+              </NavLink>
+            </NavItem>
           </Nav>
           <Nav navbar className="ml-auto">
             { this.isLoggedIn() && this.createNavLink(

--- a/dashboard/client/src/components/NavBar/NavBar.jsx
+++ b/dashboard/client/src/components/NavBar/NavBar.jsx
@@ -11,7 +11,7 @@ import {
 } from 'reactstrap';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGithub, faGitlab } from '@fortawesome/free-brands-svg-icons';
-import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
+import { faKey, faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
 
 class NavBarWithRouter extends Component {
   state = {
@@ -115,6 +115,18 @@ class NavBarWithRouter extends Component {
                 >
                   <FontAwesomeIcon icon={faGitlab} className="mr-1" />
                   GitLab
+                </NavLink>
+              </NavItem>
+            }
+            { window.PUBLIC_KEY_EXISTS &&
+              <NavItem>
+                <NavLink
+                  className="py-3 px-3 px-md-2"
+                  href="dist/pub-cert.pem"
+                  title="Encrypt function secrets for use in your git repository"
+                >
+                  <FontAwesomeIcon icon={faKey} className="mr-1" />
+                  Public Key
                 </NavLink>
               </NavItem>
             }

--- a/dashboard/client/src/components/NavBar/NavBar.jsx
+++ b/dashboard/client/src/components/NavBar/NavBar.jsx
@@ -10,7 +10,7 @@ import {
   Collapse,
 } from 'reactstrap';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { faGithub, faGitlab } from '@fortawesome/free-brands-svg-icons';
 import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
 
 class NavBarWithRouter extends Component {
@@ -94,15 +94,30 @@ class NavBarWithRouter extends Component {
         <Collapse isOpen={this.state.isActive} navbar>
           <Nav navbar>
             { this.createNavLink(pathname, user, 'Home') }
-            <NavItem>
-              <NavLink
-                className="py-3 px-3 px-md-2"
-                href="https://github.com/openfaas/openfaas-cloud"
-              >
-                <FontAwesomeIcon icon={faGithub} className="mr-1" />
-                GitHub
-              </NavLink>
-            </NavItem>
+            { window.GITHUB_APP_URL &&
+              <NavItem>
+                <NavLink
+                  className="py-3 px-3 px-md-2"
+                  href={window.GITHUB_APP_URL}
+                  title="Install on GitHub repo to deploy functions to OpenFaaS Cloud"
+                >
+                  <FontAwesomeIcon icon={faGithub} className="mr-1" />
+                  GitHub App
+                </NavLink>
+              </NavItem>
+            }
+            { window.GITLAB_URL &&
+              <NavItem>
+                <NavLink
+                  className="py-3 px-3 px-md-2"
+                  href={window.GITLAB_URL}
+                  title="GitLab instance to deploy functions to OpenFaaS Cloud"
+                >
+                  <FontAwesomeIcon icon={faGitlab} className="mr-1" />
+                  GitLab
+                </NavLink>
+              </NavItem>
+            }
           </Nav>
           <Nav navbar className="ml-auto">
             { this.isLoggedIn() && this.createNavLink(

--- a/dashboard/dashboard_config.yml
+++ b/dashboard/dashboard_config.yml
@@ -12,3 +12,8 @@ environment:
   query_pretty_url: 'true'
   # Cookie root domain, set is using OAuth, used to remove a user's cookie
   cookie_root_domain: 'system.o6s.io'
+  # Public URL for your GitHub app
+  # see https://github.com/settings/apps/
+  # github_app_url: https://github.com/apps/o6s-io
+  # Public URL for your GitLab instance
+  # gitlab_url: https://gitlab.o6s.io/

--- a/dashboard/dashboard_config.yml
+++ b/dashboard/dashboard_config.yml
@@ -17,33 +17,3 @@ environment:
   # github_app_url: https://github.com/apps/o6s-io
   # Public URL for your GitLab instance
   # gitlab_url: https://gitlab.o6s.io/
-  # SealedSecrets public key
-  # public_key: |
-  #   -----BEGIN CERTIFICATE-----
-  #   MIIErjCCApagAwIBAgIRAOpOnJ35KXJmoda4VjnxqgIwDQYJKoZIhvcNAQELBQAw
-  #   ADAeFw0yMDEwMjAyMzE5MzhaFw0zMDEwMTgyMzE5MzhaMAAwggIiMA0GCSqGSIb3
-  #   DQEBAQUAA4ICDwAwggIKAoICAQC1RNAnJC850lP00fWJVGs7y/AaWU08eitNmqgm
-  #   VkRg04baGLSOIwv5aMzHe68e1bZUAa3NzhL7lKEJdgU4+G0eidVjg4hngVvPfaCy
-  #   o6OYU+f9rTDTwOihwOu1rGBUrG42S8niWJpfDMmzyFgG/AZAJfiYOK6/FIP0JoZB
-  #   JQqorJvsmdrhve+LlwUlFIBj9cP5mWQ2OlrM49QV2rlauJfR8UEwQxsQYmxDrKxe
-  #   NltLrrsSVqqarcOCE7vHlnV+YoBK9CEAu4nCjCDV3B8fRI3ODoO5twAGJ21NeVKm
-  #   OeqgDm48lViol3Fn5iBEd1Xsp+HKG2aki7H8SkNMPvbJutt+9buhctMT1DZGfkf1
-  #   vfdYFEOQ0G8rnnYQa6hiVPwR/a1HQ0L3cSDgLCCk1O2bu69wQQDT+IdPK3HJMyWM
-  #   JgXnL3HdvuWB2/35/88pVn26tGtRLM3Ye6OqbDMpC8mvNPvKyyvwg4h+PEX5U09X
-  #   v7pJQiUCwp1bPcDGSifdN+pFvMx188G7clrLXwjW0Grvc1aXCvOM+0/ZFaxXm2DO
-  #   j0DrrvjwQy+v4DxNNjYd2n/6IJlA1ea0EV6VkS7eWhX44DU3ILwLhTo0r9TWye49
-  #   7yPJjZsyM+tTKSEBxtQ59PFpvAYC6zBMbOtn5wbVFNLuiz78lVpcvJuEfl66QoME
-  #   yposYQIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAAEwDwYDVR0TAQH/BAUwAwEB/zAN
-  #   BgkqhkiG9w0BAQsFAAOCAgEAnc5P1bXQFQXxF4+3xTsFll3JL1/b40UvnCPz8mUw
-  #   RioBFrpHp7w5ETcjGf9/ADzKx7k/ffzKPxQEiQj01Lsqy02TkQLwvWA5KXlY9OnJ
-  #   J+8IyJAbmnd6X0boMcKwtUc/vvrzkTP7gDthEX5y2kFJCCg/5k/d100U6E+1CN4h
-  #   0tSEfzKfSYW8EUHv5r4PQfFgd7n+afEGw/XURhdNUdO0a5EyvzU9510+hCZM2uRJ
-  #   KpqaQZ7tPP/pFtziDHP9imlij2CfOP5IQn8zWzbAJUK5vM/mmEyW8sDGhYno2xJS
-  #   aRR3J1m2ieDPmat56J4hVCaLQLknEsLGhbEUdJGJTdA4m8L1dYbIh2E4Nwa/WUuz
-  #   IcyQ7cTLMwHnHtB6Z35PptdJ/0SnRLut8sgj36UMxP9/McGXxoBMGT5WGfJV0n16
-  #   eRCzbWDg8xkr5ZqTofoIHs9SXx7Dm1GM+aB+rvHgQDUlnarqbQyWclqbArAqtcFI
-  #   W3bt8vFpHympK9sKNRv0oGnMdT3NJCftdkF28aXnAESv0DzkzZxOKooesNe+j5nx
-  #   jHP/isiGskK0EdOVetJN+FuDo0Ys+Ev/d7vAyy32WIcnTfbJ7nAHnhvhPCDp05F3
-  #   aAgXn0ahlcFp/HqzyD+hxPKszH1NG0WXEXIhNBr+1MoGlwTJ+PIp9oY4wt5SoKcz
-  #   rl4=
-  #   -----END CERTIFICATE-----

--- a/dashboard/dashboard_config.yml
+++ b/dashboard/dashboard_config.yml
@@ -17,3 +17,33 @@ environment:
   # github_app_url: https://github.com/apps/o6s-io
   # Public URL for your GitLab instance
   # gitlab_url: https://gitlab.o6s.io/
+  # SealedSecrets public key
+  # public_key: |
+  #   -----BEGIN CERTIFICATE-----
+  #   MIIErjCCApagAwIBAgIRAOpOnJ35KXJmoda4VjnxqgIwDQYJKoZIhvcNAQELBQAw
+  #   ADAeFw0yMDEwMjAyMzE5MzhaFw0zMDEwMTgyMzE5MzhaMAAwggIiMA0GCSqGSIb3
+  #   DQEBAQUAA4ICDwAwggIKAoICAQC1RNAnJC850lP00fWJVGs7y/AaWU08eitNmqgm
+  #   VkRg04baGLSOIwv5aMzHe68e1bZUAa3NzhL7lKEJdgU4+G0eidVjg4hngVvPfaCy
+  #   o6OYU+f9rTDTwOihwOu1rGBUrG42S8niWJpfDMmzyFgG/AZAJfiYOK6/FIP0JoZB
+  #   JQqorJvsmdrhve+LlwUlFIBj9cP5mWQ2OlrM49QV2rlauJfR8UEwQxsQYmxDrKxe
+  #   NltLrrsSVqqarcOCE7vHlnV+YoBK9CEAu4nCjCDV3B8fRI3ODoO5twAGJ21NeVKm
+  #   OeqgDm48lViol3Fn5iBEd1Xsp+HKG2aki7H8SkNMPvbJutt+9buhctMT1DZGfkf1
+  #   vfdYFEOQ0G8rnnYQa6hiVPwR/a1HQ0L3cSDgLCCk1O2bu69wQQDT+IdPK3HJMyWM
+  #   JgXnL3HdvuWB2/35/88pVn26tGtRLM3Ye6OqbDMpC8mvNPvKyyvwg4h+PEX5U09X
+  #   v7pJQiUCwp1bPcDGSifdN+pFvMx188G7clrLXwjW0Grvc1aXCvOM+0/ZFaxXm2DO
+  #   j0DrrvjwQy+v4DxNNjYd2n/6IJlA1ea0EV6VkS7eWhX44DU3ILwLhTo0r9TWye49
+  #   7yPJjZsyM+tTKSEBxtQ59PFpvAYC6zBMbOtn5wbVFNLuiz78lVpcvJuEfl66QoME
+  #   yposYQIDAQABoyMwITAOBgNVHQ8BAf8EBAMCAAEwDwYDVR0TAQH/BAUwAwEB/zAN
+  #   BgkqhkiG9w0BAQsFAAOCAgEAnc5P1bXQFQXxF4+3xTsFll3JL1/b40UvnCPz8mUw
+  #   RioBFrpHp7w5ETcjGf9/ADzKx7k/ffzKPxQEiQj01Lsqy02TkQLwvWA5KXlY9OnJ
+  #   J+8IyJAbmnd6X0boMcKwtUc/vvrzkTP7gDthEX5y2kFJCCg/5k/d100U6E+1CN4h
+  #   0tSEfzKfSYW8EUHv5r4PQfFgd7n+afEGw/XURhdNUdO0a5EyvzU9510+hCZM2uRJ
+  #   KpqaQZ7tPP/pFtziDHP9imlij2CfOP5IQn8zWzbAJUK5vM/mmEyW8sDGhYno2xJS
+  #   aRR3J1m2ieDPmat56J4hVCaLQLknEsLGhbEUdJGJTdA4m8L1dYbIh2E4Nwa/WUuz
+  #   IcyQ7cTLMwHnHtB6Z35PptdJ/0SnRLut8sgj36UMxP9/McGXxoBMGT5WGfJV0n16
+  #   eRCzbWDg8xkr5ZqTofoIHs9SXx7Dm1GM+aB+rvHgQDUlnarqbQyWclqbArAqtcFI
+  #   W3bt8vFpHympK9sKNRv0oGnMdT3NJCftdkF28aXnAESv0DzkzZxOKooesNe+j5nx
+  #   jHP/isiGskK0EdOVetJN+FuDo0Ys+Ev/d7vAyy32WIcnTfbJ7nAHnhvhPCDp05F3
+  #   aAgXn0ahlcFp/HqzyD+hxPKszH1NG0WXEXIhNBr+1MoGlwTJ+PIp9oY4wt5SoKcz
+  #   rl4=
+  #   -----END CERTIFICATE-----

--- a/dashboard/of-cloud-dashboard/handler.js
+++ b/dashboard/of-cloud-dashboard/handler.js
@@ -76,6 +76,18 @@ module.exports = async (event, context) => {
     headers['Content-Type'] = 'application/json';
   } else if (/.*\.map/.test(path)) {
     headers['Content-Type'] = 'application/octet-stream';
+  } else if (/^\/dist\/pub-cert.pem\/?$/.test(path)) {
+    if (!process.env.public_key) {
+      return context
+        .status(404)
+        .fail('Not found');
+    }
+
+    headers['Content-Type'] = 'text/plain';
+    return context
+      .headers(headers)
+      .status(200)
+      .succeed(process.env.public_key);
   }
 
   let contentPath = `${__dirname}${path}`;
@@ -129,7 +141,7 @@ module.exports = async (event, context) => {
 }
 
 function replaceTokens(content, isSignedIn, claims) {
-    const { base_href, public_url, pretty_url, query_pretty_url, github_app_url, gitlab_url } = process.env;
+    const { base_href, public_url, pretty_url, query_pretty_url, github_app_url, gitlab_url, public_key } = process.env;
     let replaced = content
 
     replaced = replaced.replace(/__BASE_HREF__/g, base_href);
@@ -140,6 +152,7 @@ function replaceTokens(content, isSignedIn, claims) {
     replaced = replaced.replace(/__ALL_CLAIMS__/g, claims);
     replaced = replaced.replace(/__GITHUB_APP_URL__/g, github_app_url || "");
     replaced = replaced.replace(/__GITLAB_URL__/g, gitlab_url || "");
+    replaced = replaced.replace(/__PUBLIC_KEY_EXISTS__/g, public_key ? "true" : "");
 
     return replaced
 }

--- a/dashboard/of-cloud-dashboard/handler.js
+++ b/dashboard/of-cloud-dashboard/handler.js
@@ -129,7 +129,7 @@ module.exports = async (event, context) => {
 }
 
 function replaceTokens(content, isSignedIn, claims) {
-    const { base_href, public_url, pretty_url, query_pretty_url } = process.env;
+    const { base_href, public_url, pretty_url, query_pretty_url, github_app_url, gitlab_url } = process.env;
     let replaced = content
 
     replaced = replaced.replace(/__BASE_HREF__/g, base_href);
@@ -138,6 +138,8 @@ function replaceTokens(content, isSignedIn, claims) {
     replaced = replaced.replace(/__QUERY_PRETTY_URL__/g, query_pretty_url);
     replaced = replaced.replace(/__IS_SIGNED_IN__/g, isSignedIn);
     replaced = replaced.replace(/__ALL_CLAIMS__/g, claims);
+    replaced = replaced.replace(/__GITHUB_APP_URL__/g, github_app_url || "");
+    replaced = replaced.replace(/__GITLAB_URL__/g, gitlab_url || "");
 
     return replaced
 }

--- a/dashboard/stack.yml
+++ b/dashboard/stack.yml
@@ -13,6 +13,8 @@ functions:
       role: openfaas-system
     environment_file:
       - dashboard/dashboard_config.yml
+    secrets:
+      - sealedsecrets-public-key
     limits:
       memory: 256Mi
     requests:


### PR DESCRIPTION
## Description
Resolves #697 
Dashboard links to GitHub app or GitLab instance and serves secrets public key if configured.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Followed ofc-bootstrap user guide using the changes in https://github.com/openfaas/ofc-bootstrap/pull/240 along with this [patch](https://github.com/wilsonianb/ofc-bootstrap/commit/d2621e8d0f145091505407f4412f417bc0f8155f) to install ofc on k3s.
Ran each of the following once with [`scm`](https://github.com/openfaas/ofc-bootstrap/blob/e16b776a352f9727594eba79af0f9b2bd0e2d8bb/example.init.yaml#L236-L237) as `github` and again as `gitlab`:
```
ofc-bootstrap apply --file init.yaml  --skip-sealedsecrets
ofc-bootstrap apply --file init.yaml
```
The deployed dashboard includes the correct icons and links based on the configuration

## How are existing users impacted? What migration steps/scripts do we need?
Setting up a repo with ofc and encrypting secrets should be easier.
The [user guide](https://docs.openfaas.com/openfaas-cloud/user-guide/) (linked to from the dashboard) and [secrets](https://docs.openfaas.com/openfaas-cloud/secrets/) docs pages could be updated to highlight the new dashboard links.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
